### PR TITLE
fix repeated graph in grafana (add missing graph)

### DIFF
--- a/grafana/Kafka_Lag_Exporter_Dashboard.json
+++ b/grafana/Kafka_Lag_Exporter_Dashboard.json
@@ -361,7 +361,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "topk(25, kafka_consumergroup_group_lag_seconds{namespace=\"$namespace\",cluster_name=\"$cluster_name\",group=~\"$consumer_group\"})",
+          "expr": "topk(25, kafka_consumergroup_group_lag{namespace=\"$namespace\",cluster_name=\"$cluster_name\",group=~\"$consumer_group\"})",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,


### PR DESCRIPTION
kafka_consumergroup_group_lag_seconds related graph is already defined at line 190. This is repeated again at line 364. It should be kafka_consumergroup_group_lag