### PR TITLE
Adding support to control which prometheus metrics to expose

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,15 +191,16 @@ defaults defined in the project itself.  See [`reference.conf`](./src/main/resou
 
 General Configuration (`kafka-lag-exporter{}`)
 
-| Key                    | Default            | Description                                                                                                                           |
-|------------------------|--------------------|---------------------------------------------------------------------------------------------------------------------------------------|
-| `port`                 | `8000`             | The port to run the Prometheus endpoint on                                                                                            |
-| `poll-interval`        | `30 seconds`       | How often to poll Kafka for latest and group offsets                                                                                  |
-| `lookup-table-size`    | `60`               | The maximum window size of the look up table **per partition**                                                                        |
-| `client-group-id`      | `kafkalagexporter` | Consumer group id of kafka-lag-exporter's client connections                                                                          |
-| `kafka-client-timeout` | `10 seconds`       | Connection timeout when making API calls to Kafka                                                                                     |
-| `clusters`             | `[]`               | A statically defined list of Kafka connection details.  This list is optional if you choose to use the Strimzi auto-discovery feature |
-| `watchers`             | `{}`               | Settings for Kafka cluster "watchers" used for auto-discovery.                                                                        |
+| Key                           | Default            | Description                                                                                                                           |
+|-------------------------------|--------------------|---------------------------------------------------------------------------------------------------------------------------------------|
+| `port`                        | `8000`             | The port to run the Prometheus endpoint on                                                                                            |
+| `poll-interval`               | `30 seconds`       | How often to poll Kafka for latest and group offsets                                                                                  |
+| `lookup-table-size`           | `60`               | The maximum window size of the look up table **per partition**                                                                        |
+| `client-group-id`             | `kafkalagexporter` | Consumer group id of kafka-lag-exporter's client connections                                                                          |
+| `kafka-client-timeout`        | `10 seconds`       | Connection timeout when making API calls to Kafka                                                                                     |
+| `clusters`                    | `[]`               | A statically defined list of Kafka connection details.  This list is optional if you choose to use the Strimzi auto-discovery feature |
+| `watchers`                    | `{}`               | Settings for Kafka cluster "watchers" used for auto-discovery.                                                                        |
+| `prometheus-metric-whitelist` | `.*`               | Regex of metrics to be exposed via Prometheus endpoint. Eg. `^kafka_consumergroup_group_max_lag.*`                                      |
 
 Kafka Cluster Connection Details (`kafka-lag-exporter.clusters[]`)
 

--- a/charts/kafka-lag-exporter/templates/030-ConfigMap.yaml
+++ b/charts/kafka-lag-exporter/templates/030-ConfigMap.yaml
@@ -36,6 +36,7 @@ data:
       watchers = {
         strimzi = "{{ .Values.watchers.strimzi }}"
       }
+      prometheus-metric-whitelist = "{{ .Values.prometheusMetricWhitelist }}"
     }
 
     akka {

--- a/charts/kafka-lag-exporter/values.yaml
+++ b/charts/kafka-lag-exporter/values.yaml
@@ -30,6 +30,9 @@ watchers:
   ## The Strimzi Cluster Watcher automatically watches for `kafka.strimzi.io` group, `Kafka` kind resources and will
   ## configure the Kafka Lag Exporter appropriately.
   strimzi: false
+## You can use regex to control the metrics exposed by Prometheus endpoint.
+## For example, if you only wish to expose the max lag metrics, use ^kafka_consumergroup_group_max_lag.*
+prometheusMetricWhitelist: .*
 
 ## The log level of the ROOT logger
 rootLogLevel: INFO

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -15,6 +15,7 @@ kafka-lag-exporter {
     strimzi = "false"
     strimzi = ${?KAFKA_LAG_EXPORTER_STRIMZI}
   }
+  prometheus-metric-whitelist = ".*"
 }
 
 akka {

--- a/src/main/scala/com/lightbend/kafkalagexporter/AppConfig.scala
+++ b/src/main/scala/com/lightbend/kafkalagexporter/AppConfig.scala
@@ -41,7 +41,8 @@ object AppConfig {
       )
     }
     val strimziWatcher = c.getString("watchers.strimzi").toBoolean
-    AppConfig(pollInterval, lookupTableSize, port, clientGroupId, kafkaClientTimeout, clusters, strimziWatcher)
+    val metricWhitelist = c.getString("prometheus-metric-whitelist")
+    AppConfig(pollInterval, lookupTableSize, port, clientGroupId, kafkaClientTimeout, clusters, strimziWatcher, metricWhitelist)
   }
 
   // Copied from Alpakka Kafka
@@ -82,7 +83,7 @@ final case class KafkaCluster(name: String, bootstrapBrokers: String,
   }
 }
 final case class AppConfig(pollInterval: FiniteDuration, lookupTableSize: Int, port: Int, clientGroupId: String,
-                           clientTimeout: FiniteDuration, clusters: List[KafkaCluster], strimziWatcher: Boolean) {
+                           clientTimeout: FiniteDuration, clusters: List[KafkaCluster], strimziWatcher: Boolean, metricWhitelist: String) {
   override def toString(): String = {
     val clusterString =
       if (clusters.isEmpty)
@@ -92,6 +93,7 @@ final case class AppConfig(pollInterval: FiniteDuration, lookupTableSize: Int, p
        |Poll interval: $pollInterval
        |Lookup table size: $lookupTableSize
        |Prometheus metrics endpoint port: $port
+       |Prometheus metrics whitelist: $metricWhitelist
        |Admin client consumer group id: $clientGroupId
        |Kafka client timeout: $clientTimeout
        |Statically defined Clusters:

--- a/src/main/scala/com/lightbend/kafkalagexporter/MainApp.scala
+++ b/src/main/scala/com/lightbend/kafkalagexporter/MainApp.scala
@@ -29,7 +29,7 @@ object MainApp extends App {
 
     val clientCreator = (cluster: KafkaCluster) =>
       KafkaClient(cluster, appConfig.clientGroupId, appConfig.clientTimeout)(kafkaClientEc)
-    val endpointCreator = () => PrometheusEndpointSink(appConfig.port, Metrics.definitions)
+    val endpointCreator = () => PrometheusEndpointSink(appConfig.port, Metrics.definitions, appConfig.metricWhitelist)
 
     ActorSystem(
       KafkaClusterManager.init(appConfig, endpointCreator, clientCreator), "kafka-lag-exporter")


### PR DESCRIPTION
This PR addresses: https://github.com/lightbend/kafka-lag-exporter/issues/43

New configuration exposed: prometheus-metric-whitelist. PrometheusEndpointSink will report or remove metrics based on this regex.