### PR TITLE
Adding support to control which prometheus metrics to expose

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,15 +191,16 @@ defaults defined in the project itself.  See [`reference.conf`](./src/main/resou
 
 General Configuration (`kafka-lag-exporter{}`)
 
-| Key                    | Default            | Description                                                                                                                           |
-|------------------------|--------------------|---------------------------------------------------------------------------------------------------------------------------------------|
-| `port`                 | `8000`             | The port to run the Prometheus endpoint on                                                                                            |
-| `poll-interval`        | `30 seconds`       | How often to poll Kafka for latest and group offsets                                                                                  |
-| `lookup-table-size`    | `60`               | The maximum window size of the look up table **per partition**                                                                        |
-| `client-group-id`      | `kafkalagexporter` | Consumer group id of kafka-lag-exporter's client connections                                                                          |
-| `kafka-client-timeout` | `10 seconds`       | Connection timeout when making API calls to Kafka                                                                                     |
-| `clusters`             | `[]`               | A statically defined list of Kafka connection details.  This list is optional if you choose to use the Strimzi auto-discovery feature |
-| `watchers`             | `{}`               | Settings for Kafka cluster "watchers" used for auto-discovery.                                                                        |
+| Key                           | Default            | Description                                                                                                                           |
+|-------------------------------|--------------------|---------------------------------------------------------------------------------------------------------------------------------------|
+| `port`                        | `8000`             | The port to run the Prometheus endpoint on                                                                                            |
+| `poll-interval`               | `30 seconds`       | How often to poll Kafka for latest and group offsets                                                                                  |
+| `lookup-table-size`           | `60`               | The maximum window size of the look up table **per partition**                                                                        |
+| `client-group-id`             | `kafkalagexporter` | Consumer group id of kafka-lag-exporter's client connections                                                                          |
+| `kafka-client-timeout`        | `10 seconds`       | Connection timeout when making API calls to Kafka                                                                                     |
+| `clusters`                    | `[]`               | A statically defined list of Kafka connection details.  This list is optional if you choose to use the Strimzi auto-discovery feature |
+| `watchers`                    | `{}`               | Settings for Kafka cluster "watchers" used for auto-discovery.                                                                        |
+| `metric-whitelist`            | `[".*"]`           | Regex of metrics to be exposed via Prometheus endpoint. Eg. `[".*_max_lag.*", "kafka_partition_latest_offset"]`                       |
 
 Kafka Cluster Connection Details (`kafka-lag-exporter.clusters[]`)
 

--- a/charts/kafka-lag-exporter/templates/030-ConfigMap.yaml
+++ b/charts/kafka-lag-exporter/templates/030-ConfigMap.yaml
@@ -41,6 +41,13 @@ data:
       watchers = {
         strimzi = "{{ .Values.watchers.strimzi }}"
       }
+      metric-whitelist = [
+        {{- $lastIndex := sub (len .Values.metricWhitelist) 1}}
+        {{- range $i, $whitelist := .Values.metricWhitelist }}
+        {{ quote $whitelist }}{{- if ne $i $lastIndex -}}, {{ end }}
+        {{- end }}
+      ]
+
     }
 
     akka {

--- a/charts/kafka-lag-exporter/values.yaml
+++ b/charts/kafka-lag-exporter/values.yaml
@@ -33,6 +33,19 @@ watchers:
   ## The Strimzi Cluster Watcher automatically watches for `kafka.strimzi.io` group, `Kafka` kind resources and will
   ## configure the Kafka Lag Exporter appropriately.
   strimzi: false
+## You can use regex to control the metrics exposed by Prometheus endpoint.
+## Any metric that matches one of the regex in the whitelist will be exposed.
+## For example, if you only wish to expose the max lag metrics, use either:
+## metricWhitelist:
+##   - ^kafka_consumergroup_group_max_lag.*
+##
+## Or
+##
+## metricWhitelist:
+##   - kafka_consumergroup_group_max_lag
+##   - kafka_consumergroup_group_max_lag_seconds
+metricWhitelist:
+  - .*
 
 ## The log level of the ROOT logger
 rootLogLevel: INFO

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -15,6 +15,7 @@ kafka-lag-exporter {
     strimzi = "false"
     strimzi = ${?KAFKA_LAG_EXPORTER_STRIMZI}
   }
+  metric-whitelist = [".*"]
 }
 
 akka {

--- a/src/main/scala/com/lightbend/kafkalagexporter/PrometheusEndpointSink.scala
+++ b/src/main/scala/com/lightbend/kafkalagexporter/PrometheusEndpointSink.scala
@@ -49,9 +49,13 @@ class PrometheusEndpointSink private(definitions: MetricDefinitions, metricWhite
 
   override def remove(m: RemoveMetric): Unit = {
     if(metricWhitelist.exists(m.definition.name.matches)) {
-      metrics.foreach { case (_, gaugeDefinitionsForCluster) =>
-        val globalLabelValuesForCluster = clusterGlobalLabels.getOrElse(m.clusterName, Map.empty)
-        gaugeDefinitionsForCluster.get(m.definition).foreach(_.remove(globalLabelValuesForCluster.values.toSeq ++ m.labels: _*))
+      for(
+        clusterMetrics <- metrics.get(m.clusterName);
+        globalLabels <- clusterGlobalLabels.get(m.clusterName);
+        gauge <- clusterMetrics.get(m.definition)
+      ) {
+        val metricLabels = globalLabels.values.toList ++ m.labels
+        gauge.remove(metricLabels: _*)
       }
     }
   }

--- a/src/test/scala/com/lightbend/kafkalagexporter/PrometheusEndpointSinkTest.scala
+++ b/src/test/scala/com/lightbend/kafkalagexporter/PrometheusEndpointSinkTest.scala
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) 2019 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package com.lightbend.kafkalagexporter
+
+import java.net.ServerSocket
+
+import io.prometheus.client.CollectorRegistry
+import io.prometheus.client.exporter.HTTPServer
+import org.scalatest._
+
+import scala.collection.JavaConverters._
+import scala.util.{Failure, Success, Try}
+
+class PrometheusEndpointSinkTest extends fixture.FreeSpec with Matchers {
+
+  case class Fixture(server: HTTPServer, registry: CollectorRegistry)
+  type FixtureParam = Fixture
+
+  override def withFixture(test: OneArgTest): Outcome = {
+    val httpServer =
+      Try(new ServerSocket(0)) match {
+        case Success(socket) =>
+          val freePort = socket.getLocalPort
+          socket.close()
+          new HTTPServer(freePort)
+        case Failure(exception) => throw exception
+      }
+    val registry = CollectorRegistry.defaultRegistry
+    try test(Fixture(httpServer, registry))
+    finally {
+      registry.clear()
+      httpServer.stop()
+    }
+  }
+
+  "PrometheusEndpointSinkImpl should" - {
+
+    "register only metrics which match the regex" in { fixture =>
+      PrometheusEndpointSink(Metrics.definitions, List(".*max_lag.*"), Map("cluster" -> Map.empty), fixture.server, fixture.registry)
+      val metricSamples = fixture.registry.metricFamilySamples().asScala.toSet
+
+      metricSamples.map(_.name).intersect(Metrics.definitions.map(_.name).toSet) should contain theSameElementsAs
+        Set("kafka_consumergroup_group_max_lag", "kafka_consumergroup_group_max_lag_seconds")
+    }
+
+    "append global labels to metric labels" in { fixture =>
+      val groupLabel = Map(
+        "cluster" -> Map(
+          "environment" ->"dev",
+          "org" -> "organization",
+        )
+      )
+      val sink = PrometheusEndpointSink(Metrics.definitions, List(".*"), groupLabel, fixture.server, fixture.registry)
+      sink.report(Metrics.GroupValueMessage(Metrics.MaxGroupTimeLagMetric, "cluster", "group", 1))
+
+      val metricSamples = fixture.registry.metricFamilySamples().asScala.toList
+      val maxGroupTimeLagMetricSamples = metricSamples.filter(_.name.equals(Metrics.MaxGroupTimeLagMetric.name)).flatMap(_.samples.asScala)
+
+      maxGroupTimeLagMetricSamples should have length 1
+      val labels = maxGroupTimeLagMetricSamples.flatMap(_.labelNames.asScala)
+      val labelValues = maxGroupTimeLagMetricSamples.flatMap(_.labelValues.asScala)
+      (labels zip labelValues).toMap should contain theSameElementsAs
+        Map(
+          "environment" ->"dev",
+          "org" -> "organization",
+          "cluster_name" -> "cluster",
+          "group" -> "group",
+        )
+
+      sink.remove(Metrics.GroupRemoveMetricMessage(Metrics.MaxGroupTimeLagMetric, "cluster", "group"))
+
+      val metricSamplesAfterRemoval = fixture.registry.metricFamilySamples().asScala.toList
+      val maxGroupTimeLagMetricSamplesAfterRemoval = metricSamplesAfterRemoval.filter(_.name.equals(Metrics.MaxGroupTimeLagMetric.name)).flatMap(_.samples.asScala)
+
+
+      maxGroupTimeLagMetricSamplesAfterRemoval should have length 0
+    }
+
+    "report only metrics which match the regex" in { fixture =>
+      val sink = PrometheusEndpointSink(Metrics.definitions, List("kafka_consumergroup_group_max_lag"), Map("cluster" -> Map.empty),
+        fixture.server, fixture.registry)
+      sink.report(Metrics.GroupValueMessage(Metrics.MaxGroupOffsetLagMetric, "cluster", "group", 100))
+      sink.report(Metrics.GroupValueMessage(Metrics.MaxGroupTimeLagMetric, "cluster", "group", 1))
+      val labels = Array[String]("cluster_name", "group")
+      val labelVals = Array[String]("cluster", "group")
+      fixture.registry.getSampleValue("kafka_consumergroup_group_max_lag", labels, labelVals) should be (100)
+      val metricSamples = fixture.registry.metricFamilySamples().asScala.toSet
+      metricSamples.map(_.name) should not contain "kafka_consumergroup_group_max_lag_seconds"
+    }
+
+    "remove only metrics which match the regex" in { fixture =>
+      val sink = PrometheusEndpointSink(Metrics.definitions, List("kafka_consumergroup_group_max_lag"), Map("cluster" -> Map.empty),
+        fixture.server, fixture.registry)
+      sink.report(Metrics.GroupValueMessage(Metrics.MaxGroupOffsetLagMetric, "cluster", "group", 100))
+      sink.remove(Metrics.GroupRemoveMetricMessage(Metrics.MaxGroupOffsetLagMetric, "cluster", "group"))
+      sink.remove(Metrics.GroupRemoveMetricMessage(Metrics.MaxGroupTimeLagMetric, "cluster", "group"))
+      val labels = Array[String]("cluster_name", "group")
+      val labelVals = Array[String]("cluster", "group")
+      fixture.registry.getSampleValue("kafka_consumergroup_group_max_lag", labels, labelVals) should be (null)
+    }
+
+  }
+
+}


### PR DESCRIPTION
This PR addresses: #43

New configuration exposed: metric-whitelist. PrometheusEndpointSink will report or remove metrics based on the list of regex.

This PR also added test cases for PrometheusEndpointSink, and fix a bug where metrics removal does not consider global tags.