### PR TITLE
Omit service account generation when not using strimzi (#53)

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,17 @@ helm install https://github.com/lightbend/kafka-lag-exporter/releases/download/v
   --set clusters\[0\].bootstrapBrokers=my-cluster-kafka-bootstrap:9092
 ```
 
+Install with statically defined cluster at the CLI, but with a non-default service account assigned to the deployment.
+
+```
+helm install https://github.com/lightbend/kafka-lag-exporter/releases/download/v0.5.1/kafka-lag-exporter-0.5.1.tgz \
+  --name kafka-lag-exporter \
+  --namespace myproject \
+  --set clusters\[0\].name=my-cluster \
+  --set clusters\[0\].bootstrapBrokers=my-cluster-kafka-bootstrap:9092
+  --set serviceAccount.create=true
+```
+
 Run a debug install (`DEBUG` logging, debug helm chart install, force docker pull policy to `Always`).
 
 ```

--- a/charts/kafka-lag-exporter/templates/000-ServiceAccount.yaml
+++ b/charts/kafka-lag-exporter/templates/000-ServiceAccount.yaml
@@ -1,3 +1,4 @@
+{{- if or .Values.watchers.strimzi .Values.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -7,3 +8,4 @@ metadata:
     helm.sh/chart: {{ include "kafka-lag-exporter.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}

--- a/charts/kafka-lag-exporter/templates/040-Deployment.yaml
+++ b/charts/kafka-lag-exporter/templates/040-Deployment.yaml
@@ -23,7 +23,9 @@ spec:
         app.kubernetes.io/name: {{ include "kafka-lag-exporter.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
+      {{- if or .Values.watchers.strimzi .Values.serviceAccount.create -}}
       serviceAccountName: {{ include "kafka-lag-exporter.fullname" . }}-serviceaccount
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/charts/kafka-lag-exporter/values.yaml
+++ b/charts/kafka-lag-exporter/values.yaml
@@ -33,6 +33,11 @@ watchers:
   ## The Strimzi Cluster Watcher automatically watches for `kafka.strimzi.io` group, `Kafka` kind resources and will
   ## configure the Kafka Lag Exporter appropriately.
   strimzi: false
+## Applicable only in non-Strimzi installation. If true, a service account will be created and bind to the deployment.
+## Otherwise, the default service account for the namespace will be used.
+serviceAccount:
+  create: false
+
 ## You can use regex to control the metrics exposed by Prometheus endpoint.
 ## Any metric that matches one of the regex in the whitelist will be exposed.
 ## For example, if you only wish to expose the max lag metrics, use either:


### PR DESCRIPTION
Addresses https://github.com/lightbend/kafka-lag-exporter/issues/53.

In this PR, i generate the service account dynamically, rather than using a user input as originally discussed in issue 53. If we rely on user input, the helm chart will fail if it is executed twice under different helm release name, as the service account would have already existed.

