### PR TITLE
Fix Helm Chart: Whitespace in Deployment.yaml

### DIFF
--- a/charts/kafka-lag-exporter/templates/040-Deployment.yaml
+++ b/charts/kafka-lag-exporter/templates/040-Deployment.yaml
@@ -23,7 +23,7 @@ spec:
         app.kubernetes.io/name: {{ include "kafka-lag-exporter.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
-      {{- if or .Values.watchers.strimzi .Values.serviceAccount.create -}}
+      {{- if or .Values.watchers.strimzi .Values.serviceAccount.create }}
       serviceAccountName: {{ include "kafka-lag-exporter.fullname" . }}-serviceaccount
       {{- end }}
       containers:


### PR DESCRIPTION
Extra whitespace is being removed while templating `serviceAccountName` in file `charts/kafka-lag-exporter/templates/040-Deployment.yaml`

This leads to the following error when templating/installing the helm chart with `watchers.strimzi` or `serviceAccount.create` enabled:
```
Error: UPGRADE FAILED: YAML parse error on kafka-lag-exporter/templates/040-Deployment.yaml: error converting YAML to JSON: yaml: line 21: mapping values are not allowed in this context
```

This happens because it is being templated as:
```
spec: serviceAccountName: {{ include "kafka-lag-exporter.fullname" . }}-serviceaccount
```
instead of 

```
spec: 
  serviceAccountName: {{ include "kafka-lag-exporter.fullname" . }}-serviceaccount
```