### PR TITLE
Fix Helm Chart Regression: Use Official Image Repo

### DIFF
--- a/charts/kafka-lag-exporter/values.yaml
+++ b/charts/kafka-lag-exporter/values.yaml
@@ -64,7 +64,7 @@ akkaLogLevel: DEBUG
 
 ## You probably won't need to change anything below this line.
 image:
-  repository: localhost:32000/seglo/kafka-lag-exporter
+  repository: lightbend/kafka-lag-exporter
   tag: 0.5.4-SNAPSHOT
   pullPolicy: Always
 service:


### PR DESCRIPTION
Looks like some testing code leaked into the final change. The image should be `lightbend/kafka-lag-exporter` instead of `localhost:32000/seglo/kafka-lag-exporter`

Git blame shows this commit responsible for this change: https://github.com/lightbend/kafka-lag-exporter/commit/946f90d49b0f7633466b83f5ccbe8946510ea3f3

@seglo can you confirm?