### PR TITLE
Avoid recreating the metrics for each cluster to support global labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,8 @@ The latest offset available for topic partition.  Kafka Lag Exporter will calcul
 
 ### Labels
 
-Each metric may include the following labels when reported.
+Each metric may include the following labels when reported. If you define the labels property for Configuration of a cluster then those labels will also be included. 
+If certain labels are not defined in any of the clusters but present in other cluster, it will be just blank.
 
 * `cluster_name` - Either the statically defined Kafka cluster name, or the metadata.name of the Strimzi Kafka cluster that was discovered with the Strimzi auto discovery feature.
 * `topic` - The Kafka topic.
@@ -224,7 +225,7 @@ Kafka Cluster Connection Details (`kafka-lag-exporter.clusters[]`)
 | `topic-whitelist`         | `[".*"]`      No       | A list of Regex of topics monitored. For example, if you only wish to expose only certain topics, use either `["^topic.+"]` or `["topic1", "topic2"]`.                                             |
 | `consumer-properties`     | `{}`        | No       | A map of key value pairs used to configure the `KafkaConsumer`. See the [Consumer Config](https://kafka.apache.org/documentation/#consumerconfigs) section of the Kafka documentation for options. |
 | `admin-client-properties` | `{}`        | No       | A map of key value pairs used to configure the `AdminClient`. See the [Admin Config](https://kafka.apache.org/documentation/#adminclientconfigs) section of the Kafka documentation for options.   |
-| ~~`labels`~~              | `{}`        | No       | Disabled until there's a resolution in [#78](https://github.com/lightbend/kafka-lag-exporter/pull/78) ~~A map of key value pairs will be set as additional custom labels per cluster for all the metrics in prometheus.~~ |
+| `labels`                  | `{}`        | No       | A map of key value pairs will be set as additional custom labels per cluster for all the metrics in prometheus.                                                                                    |
 
 Watchers (`kafka-lag-exporters.watchers{}`)
 
@@ -252,6 +253,10 @@ kafka-lag-exporter {
       }
       admin-client-properties = {
         client.id = "admin-client-id"
+      }
+      labels = {
+        location = "ny"
+        zone = "us-east"
       }
     }
   ]

--- a/README.md
+++ b/README.md
@@ -97,8 +97,8 @@ The latest offset available for topic partition.  Kafka Lag Exporter will calcul
 
 ### Labels
 
-Each metric may include the following labels when reported. If you define the labels property for Configuration of a cluster then those labels will also be included. 
-If certain labels are not defined in any of the clusters but present in other cluster, it will be just blank.
+Each metric may include the following labels when reported. If you define the `labels` property for configuration of a cluster then those labels will also be included. 
+The superset of all `labels` defined for all cluster configurations are used for each metric. This is due to a restriction in the Java Prometheus client library that only allows us to define one set of labels per metric. Therefore, if the label names across cluster configurations are not consistent then the missing labels for each cluster will appear as blank values (`""`) in the reported metric. An alternative to defining labels in Kafka Lag Exporter is to define [relabeling rules](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config) in your Prometheus server configuration.
 
 * `cluster_name` - Either the statically defined Kafka cluster name, or the metadata.name of the Strimzi Kafka cluster that was discovered with the Strimzi auto discovery feature.
 * `topic` - The Kafka topic.

--- a/charts/kafka-lag-exporter/values.yaml
+++ b/charts/kafka-lag-exporter/values.yaml
@@ -20,6 +20,9 @@ clusters: {}
 #      security.protocol: SSL
 #      ssl.truststore.location: /path/to/my.truststore.jks
 #      ssl.trustore.password: mypwd
+#    labels:
+#      location: ny
+#      zone: "us-east"
 
 ## The interval between refreshing metrics
 pollIntervalSeconds: 30

--- a/src/main/scala/com/lightbend/kafkalagexporter/AppConfig.scala
+++ b/src/main/scala/com/lightbend/kafkalagexporter/AppConfig.scala
@@ -134,11 +134,8 @@ final case class AppConfig(pollInterval: FiniteDuration, lookupTableSize: Int, p
   }
 
   def clustersGlobalLabels(): ClusterGlobalLabels = {
-    val allDistinctLabelKeys = clusters.flatMap(_.labels.keys).distinct
     clusters.map { cluster =>
-      cluster.name -> allDistinctLabelKeys.map { label =>
-        label -> cluster.labels.getOrElse(label, "")
-      }.toMap
+      cluster.name -> cluster.labels
     }.toMap
   }
 }

--- a/src/main/scala/com/lightbend/kafkalagexporter/AppConfig.scala
+++ b/src/main/scala/com/lightbend/kafkalagexporter/AppConfig.scala
@@ -134,8 +134,11 @@ final case class AppConfig(pollInterval: FiniteDuration, lookupTableSize: Int, p
   }
 
   def clustersGlobalLabels(): ClusterGlobalLabels = {
+    val allDistinctLabelKeys = clusters.flatMap(_.labels.keys).distinct
     clusters.map { cluster =>
-      cluster.name -> cluster.labels
+      cluster.name -> allDistinctLabelKeys.map { label =>
+        label -> cluster.labels.getOrElse(label, "")
+      }.toMap
     }.toMap
   }
 }

--- a/src/main/scala/com/lightbend/kafkalagexporter/PrometheusEndpointSink.scala
+++ b/src/main/scala/com/lightbend/kafkalagexporter/PrometheusEndpointSink.scala
@@ -5,6 +5,7 @@
 package com.lightbend.kafkalagexporter
 
 import com.lightbend.kafkalagexporter.MetricsSink._
+import com.lightbend.kafkalagexporter.PrometheusEndpointSink.{ClusterGlobalLabels, Metrics}
 import io.prometheus.client.exporter.HTTPServer
 import io.prometheus.client.hotspot.DefaultExports
 import io.prometheus.client.{CollectorRegistry, Gauge}
@@ -15,45 +16,48 @@ object PrometheusEndpointSink {
   type ClusterName = String
   type GlobalLabels = Map[String, String]
   type ClusterGlobalLabels = Map[ClusterName, GlobalLabels]
+  type Metrics = Map[GaugeDefinition, Gauge]
 
   def apply(definitions: MetricDefinitions, metricWhitelist: List[String], clusterGlobalLabels: ClusterGlobalLabels,
             server: HTTPServer, registry: CollectorRegistry): MetricsSink = {
-    Try(new PrometheusEndpointSink(definitions, metricWhitelist, server, registry))
+    Try(new PrometheusEndpointSink(definitions, metricWhitelist, clusterGlobalLabels, server, registry))
       .fold(t => throw new Exception("Could not create Prometheus Endpoint", t), sink => sink)
   }
 }
 
-class PrometheusEndpointSink private(definitions: MetricDefinitions, metricWhitelist: List[String],
+class PrometheusEndpointSink private(definitions: MetricDefinitions, metricWhitelist: List[String], clusterGlobalLabels: ClusterGlobalLabels,
                                      server: HTTPServer, registry: CollectorRegistry) extends MetricsSink {
-
   DefaultExports.initialize()
 
-  private val metrics: Map[GaugeDefinition, Gauge] = register()
-
-  private def register(): Map[GaugeDefinition, Gauge] = {
-    definitions
-      .filter(d => metricWhitelist.exists(d.name.matches))
-      .map { d =>
-        d -> Gauge
-          .build()
-          .name(d.name)
-          .help(d.help)
-          .labelNames(d.labels: _*)
-          .register(registry)
-      }
-      .toMap
+  private val metrics: Metrics = {
+    val globalLabels = clusterGlobalLabels.values.headOption.getOrElse(Map.empty).keys.toSeq
+    definitions.filter(d => metricWhitelist.exists(d.name.matches)).map { d =>
+      d -> Gauge.build()
+        .name(d.name)
+        .help(d.help)
+        .labelNames(globalLabels ++ d.labels: _*)
+        .register(registry)
+    }.toMap
   }
 
+
   override def report(m: MetricValue): Unit = {
-    if(metricWhitelist.exists(m.definition.name.matches)) {
+    if (metricWhitelist.exists(m.definition.name.matches)) {
       val metric = metrics.getOrElse(m.definition, throw new IllegalArgumentException(s"No metric with definition ${m.definition.name} registered"))
-      metric.labels(m.labels: _*).set(m.value)
+      val globalLabelValuesForCluster = clusterGlobalLabels.getOrElse(m.clusterName, Map.empty)
+      metric.labels(globalLabelValuesForCluster.values.toSeq ++ m.labels: _*).set(m.value)
     }
   }
 
   override def remove(m: RemoveMetric): Unit = {
-    if(metricWhitelist.exists(m.definition.name.matches)) {
-      metrics.get(m.definition).foreach(_.remove(m.labels: _*))
+    if (metricWhitelist.exists(m.definition.name.matches)) {
+      for (
+        globalLabels <- clusterGlobalLabels.get(m.clusterName);
+        gauge <- metrics.get(m.definition)
+      ) {
+        val metricLabels = globalLabels.values.toList ++ m.labels
+        gauge.remove(metricLabels: _*)
+      }
     }
   }
 

--- a/src/test/scala/com/lightbend/kafkalagexporter/AppConfigSpec.scala
+++ b/src/test/scala/com/lightbend/kafkalagexporter/AppConfigSpec.scala
@@ -8,38 +8,39 @@ import org.scalatest.{FreeSpec, Matchers}
 
 class AppConfigSpec extends FreeSpec with Matchers {
 
-  val configString = s"""
-                        |kafka-lag-exporter {
-                        |  clusters = [
-                        |    {
-                        |       name = "clusterA"
-                        |       bootstrap-brokers = "b-1.cluster-a.xyzcorp.com:9092,b-2.cluster-a.xyzcorp.com:9092"
-                        |       group-whitelist = ["group-a", "group-b"]
-                        |       topic-whitelist = ["topic-a", "topic-b"]
-                        |       consumer-properties = {
-                        |         client.id = "consumer-client-id"
-                        |       }
-                        |       admin-client-properties = {
-                        |         client.id = "admin-client-id"
-                        |       }
-                        |       labels = {
-                        |         environment= "integration"
-                        |         location = "ny"
-                        |       }
-                        |    }
-                        |    {
-                        |       name = "clusterB"
-                        |       bootstrap-brokers = "b-1.cluster-b.xyzcorp.com:9092,b-2.cluster-b.xyzcorp.com:9092"
-                        |       labels = {
-                        |         environment= "production"
-                        |       }
-                        |    }
-                        |    {
-                        |       name = "clusterC"
-                        |       bootstrap-brokers = "c-1.cluster-b.xyzcorp.com:9092,c-2.cluster-b.xyzcorp.com:9092"
-                        |    }
-                        |  ]
-                        |}""".stripMargin
+  val configString =
+    s"""
+       |kafka-lag-exporter {
+       |  clusters = [
+       |    {
+       |       name = "clusterA"
+       |       bootstrap-brokers = "b-1.cluster-a.xyzcorp.com:9092,b-2.cluster-a.xyzcorp.com:9092"
+       |       group-whitelist = ["group-a", "group-b"]
+       |       topic-whitelist = ["topic-a", "topic-b"]
+       |       consumer-properties = {
+       |         client.id = "consumer-client-id"
+       |       }
+       |       admin-client-properties = {
+       |         client.id = "admin-client-id"
+       |       }
+       |       labels = {
+       |         environment= "integration"
+       |         location = "ny"
+       |       }
+       |    }
+       |    {
+       |       name = "clusterB"
+       |       bootstrap-brokers = "b-1.cluster-b.xyzcorp.com:9092,b-2.cluster-b.xyzcorp.com:9092"
+       |       labels = {
+       |         environment= "production"
+       |       }
+       |    }
+       |    {
+       |       name = "clusterC"
+       |       bootstrap-brokers = "c-1.cluster-b.xyzcorp.com:9092,c-2.cluster-b.xyzcorp.com:9092"
+       |    }
+       |  ]
+       |}""".stripMargin
 
   "AppConfig" - {
     "should parse static clusters" in {
@@ -72,8 +73,8 @@ class AppConfigSpec extends FreeSpec with Matchers {
       appConfig.clustersGlobalLabels() should contain theSameElementsAs
         Map(
           "clusterA" -> Map("environment" -> "integration", "location" -> "ny"),
-          "clusterB" -> Map("environment" -> "production", "location" -> ""),
-          "clusterC" -> Map("environment" -> "", "location" -> "")
+          "clusterB" -> Map("environment" -> "production"),
+          "clusterC" -> Map.empty
         )
     }
 

--- a/src/test/scala/com/lightbend/kafkalagexporter/AppConfigSpec.scala
+++ b/src/test/scala/com/lightbend/kafkalagexporter/AppConfigSpec.scala
@@ -8,41 +8,42 @@ import org.scalatest.{FreeSpec, Matchers}
 
 class AppConfigSpec extends FreeSpec with Matchers {
 
+  val configString = s"""
+                        |kafka-lag-exporter {
+                        |  clusters = [
+                        |    {
+                        |       name = "clusterA"
+                        |       bootstrap-brokers = "b-1.cluster-a.xyzcorp.com:9092,b-2.cluster-a.xyzcorp.com:9092"
+                        |       group-whitelist = ["group-a", "group-b"]
+                        |       topic-whitelist = ["topic-a", "topic-b"]
+                        |       consumer-properties = {
+                        |         client.id = "consumer-client-id"
+                        |       }
+                        |       admin-client-properties = {
+                        |         client.id = "admin-client-id"
+                        |       }
+                        |       labels = {
+                        |         environment= "integration"
+                        |         location = "ny"
+                        |       }
+                        |    }
+                        |    {
+                        |       name = "clusterB"
+                        |       bootstrap-brokers = "b-1.cluster-b.xyzcorp.com:9092,b-2.cluster-b.xyzcorp.com:9092"
+                        |       labels = {
+                        |         environment= "production"
+                        |       }
+                        |    }
+                        |    {
+                        |       name = "clusterC"
+                        |       bootstrap-brokers = "c-1.cluster-b.xyzcorp.com:9092,c-2.cluster-b.xyzcorp.com:9092"
+                        |    }
+                        |  ]
+                        |}""".stripMargin
+
   "AppConfig" - {
     "should parse static clusters" in {
-      val config: Config = loadConfig(s"""
-                                         |kafka-lag-exporter {
-                                         |  clusters = [
-                                         |    {
-                                         |       name = "clusterA"
-                                         |       bootstrap-brokers = "b-1.cluster-a.xyzcorp.com:9092,b-2.cluster-a.xyzcorp.com:9092"
-                                         |       group-whitelist = ["group-a", "group-b"]
-                                         |       topic-whitelist = ["topic-a", "topic-b"]
-                                         |       consumer-properties = {
-                                         |         client.id = "consumer-client-id"
-                                         |       }
-                                         |       admin-client-properties = {
-                                         |         client.id = "admin-client-id"
-                                         |       }
-                                         |       labels = {
-                                         |         environment= "integration"
-                                         |         location = "ny"
-                                         |       }
-                                         |    }
-                                         |    {
-                                         |       name = "clusterB"
-                                         |       bootstrap-brokers = "b-1.cluster-b.xyzcorp.com:9092,b-2.cluster-b.xyzcorp.com:9092"
-                                         |       labels = {
-                                         |         environment= "production"
-                                         |       }
-                                         |    }
-                                         |    {
-                                         |       name = "clusterC"
-                                         |       bootstrap-brokers = "c-1.cluster-b.xyzcorp.com:9092,c-2.cluster-b.xyzcorp.com:9092"
-                                         |    }
-                                         |  ]
-                                         |}""".stripMargin)
-
+      val config: Config = loadConfig(configString)
       val appConfig = AppConfig(config)
 
       appConfig.clusters.length shouldBe 3
@@ -64,6 +65,21 @@ class AppConfigSpec extends FreeSpec with Matchers {
       appConfig.clusters(2).consumerProperties shouldBe Map.empty
       appConfig.clusters(2).adminClientProperties shouldBe Map.empty
       appConfig.clusters(2).labels shouldBe Map.empty
+    }
+
+    "should set blank string for the clusters if label value is absent" in {
+      val appConfig = AppConfig(loadConfig(configString))
+      appConfig.clustersGlobalLabels() should contain theSameElementsAs
+        Map(
+          "clusterA" -> Map("environment" -> "integration", "location" -> "ny"),
+          "clusterB" -> Map("environment" -> "production", "location" -> ""),
+          "clusterC" -> Map("environment" -> "", "location" -> "")
+        )
+    }
+
+    "should handle the empty config case" in {
+      val appConfig = AppConfig(loadConfig(""))
+      appConfig.clustersGlobalLabels() should equal(Map.empty)
     }
   }
 

--- a/src/test/scala/com/lightbend/kafkalagexporter/PrometheusEndpointSinkTest.scala
+++ b/src/test/scala/com/lightbend/kafkalagexporter/PrometheusEndpointSinkTest.scala
@@ -173,21 +173,21 @@ class PrometheusEndpointSinkTest extends fixture.FreeSpec with Matchers {
         "clusterC" -> Map.empty[String, String]
       )
       val sink = PrometheusEndpointSink(Metrics.definitions, List(""), clustersGlobalValuesMap, fixture.server, fixture.registry).asInstanceOf[PrometheusEndpointSink]
-      sink.globalLabelNames() shouldEqual List("environment", "location")
-      sink.getGlobalLabelNames("clusterA") shouldEqual List("integration", "ny")
-      sink.getGlobalLabelNames("clusterB") shouldEqual List("production", "")
-      sink.getGlobalLabelNames("clusterC") shouldEqual List("", "")
-      sink.getGlobalLabelNames("strimzi-cluster") shouldEqual List("", "")
+      sink.globalLabelNames shouldEqual List("environment", "location")
+      sink.getGlobalLabelValuesOrDefault("clusterA") shouldEqual List("integration", "ny")
+      sink.getGlobalLabelValuesOrDefault("clusterB") shouldEqual List("production", "")
+      sink.getGlobalLabelValuesOrDefault("clusterC") shouldEqual List("", "")
+      sink.getGlobalLabelValuesOrDefault("strimzi-cluster") shouldEqual List("", "")
     }
 
     "should add blank value for the cluster label for the cluster label is not specified for the cluster" in { fixture =>
       val clustersGlobalValuesMap = Map.empty[String, Map[String, String]]
       val sink = PrometheusEndpointSink(Metrics.definitions, List(""), clustersGlobalValuesMap, fixture.server, fixture.registry).asInstanceOf[PrometheusEndpointSink]
-      sink.globalLabelNames() shouldEqual List.empty
-      sink.getGlobalLabelNames("clusterA") shouldEqual List.empty
-      sink.getGlobalLabelNames("clusterB") shouldEqual List.empty
-      sink.getGlobalLabelNames("clusterC") shouldEqual List.empty
-      sink.getGlobalLabelNames("strimzi-cluster") shouldEqual List.empty
+      sink.globalLabelNames shouldEqual List.empty
+      sink.getGlobalLabelValuesOrDefault("clusterA") shouldEqual List.empty
+      sink.getGlobalLabelValuesOrDefault("clusterB") shouldEqual List.empty
+      sink.getGlobalLabelValuesOrDefault("clusterC") shouldEqual List.empty
+      sink.getGlobalLabelValuesOrDefault("strimzi-cluster") shouldEqual List.empty
     }
   }
 


### PR DESCRIPTION
This fixes the issue reproduced in [78](https://github.com/lightbend/kafka-lag-exporter/pull/78).
Java prometheus client library does not let us register metrics more than once with different sets of labels. The idea is not to register prometheus metrics for each cluster and to create once with all the labels defined in all the cluster. 



