### PR TITLE
Added collection and export of Earliest Offset

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,13 @@ Labels: `cluster_name, topic, partition`
 
 The latest offset available for topic partition.  Kafka Lag Exporter will calculate a set of partitions for all consumer groups available and then poll for the last produced offset.  The last produced offset is used in the calculation of other metrics provided, so it is exported for informational purposes.  For example, the accompanying Grafana dashboard makes use of it to visualize the last produced offset and the last consumed offset in certain panels.
 
+**`kafka_partition_earliest_offset`**
+
+Labels: `cluster_name, topic, partition`
+
+The earliest offset available for topic partition.  Kafka Lag Exporter will calculate a set of partitions for all consumer groups available and then poll for the earliest available offset.  The earliest available offset is used in the calculation of other metrics provided, so it is exported for informational purposes.  For example, the accompanying Grafana dashboard makes use of it to visualize the offset-based volume of a partition in certain panels.
+
+
 ### Labels
 
 Each metric may include the following labels when reported. If you define the `labels` property for configuration of a cluster then those labels will also be included. 
@@ -125,7 +132,7 @@ file of the accompanying Helm Chart.
 You can install the chart from the local filesystem.
 
 ```
-helm install https://github.com/lightbend/kafka-lag-exporter/releases/download/v0.5.4/kafka-lag-exporter-0.5.4.tgz
+helm install https://github.com/lightbend/kafka-lag-exporter/releases/download/v0.5.5/kafka-lag-exporter-0.5.5.tgz
 ```
 
 #### Examples
@@ -134,7 +141,7 @@ Install with the [Strimzi](https://strimzi.io/) Kafka discovery feature.
 See [Strimzi Kafka Cluster Watcher](#strimzi-kafka-cluster-watcher) for more details.
 
 ```
-helm install https://github.com/lightbend/kafka-lag-exporter/releases/download/v0.5.4/kafka-lag-exporter-0.5.4.tgz \
+helm install https://github.com/lightbend/kafka-lag-exporter/releases/download/v0.5.5/kafka-lag-exporter-0.5.5.tgz \
   --name kafka-lag-exporter \
   --namespace kafka-lag-exporter \
   --set watchers.strimzi=true
@@ -143,7 +150,7 @@ helm install https://github.com/lightbend/kafka-lag-exporter/releases/download/v
 Install with statically defined cluster at the CLI.
 
 ```
-helm install https://github.com/lightbend/kafka-lag-exporter/releases/download/v0.5.4/kafka-lag-exporter-0.5.4.tgz \
+helm install https://github.com/lightbend/kafka-lag-exporter/releases/download/v0.5.5/kafka-lag-exporter-0.5.5.tgz \
   --name kafka-lag-exporter \
   --namespace myproject \
   --set clusters\[0\].name=my-cluster \
@@ -153,7 +160,7 @@ helm install https://github.com/lightbend/kafka-lag-exporter/releases/download/v
 Install with statically defined cluster at the CLI, but with a non-default service account assigned to the deployment.
 
 ```
-helm install https://github.com/lightbend/kafka-lag-exporter/releases/download/v0.5.4/kafka-lag-exporter-0.5.4.tgz \
+helm install https://github.com/lightbend/kafka-lag-exporter/releases/download/v0.5.5/kafka-lag-exporter-0.5.5.tgz \
   --name kafka-lag-exporter \
   --namespace myproject \
   --set clusters\[0\].name=my-cluster \
@@ -164,7 +171,7 @@ helm install https://github.com/lightbend/kafka-lag-exporter/releases/download/v
 Run a debug install (`DEBUG` logging, debug helm chart install, force docker pull policy to `Always`).
 
 ```
-helm install https://github.com/lightbend/kafka-lag-exporter/releases/download/v0.5.4/kafka-lag-exporter-0.5.4.tgz \
+helm install https://github.com/lightbend/kafka-lag-exporter/releases/download/v0.5.5/kafka-lag-exporter-0.5.5.tgz \
   --name kafka-lag-exporter \
   --namespace myproject \
   --set image.pullPolicy=Always \
@@ -275,7 +282,7 @@ Ex)
 ```
 docker run -p 8000:8000 \
     -v $(pwd):/opt/docker/conf/ \
-    lightbend/kafka-lag-exporter:0.5.4 \
+    lightbend/kafka-lag-exporter:0.5.5 \
     /opt/docker/bin/kafka-lag-exporter \
     -Dconfig.file=/opt/docker/conf/application.conf \
     -Dlogback.configurationFile=/opt/docker/conf/logback.xml
@@ -476,6 +483,10 @@ required.  Before running a release make sure the following pre-req's are met.
 4. Review the GitHub release draft and submit it.
 
 ## Change log
+
+0.5.5
+
+* Added kafka_partition_earliest_offset metric for determining the volume of offsets stored in Kafka.
 
 0.5.4
 

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ file of the accompanying Helm Chart.
 You can install the chart from the local filesystem.
 
 ```
-helm install https://github.com/lightbend/kafka-lag-exporter/releases/download/v0.5.5/kafka-lag-exporter-0.5.5.tgz
+helm install https://github.com/lightbend/kafka-lag-exporter/releases/download/v0.5.4/kafka-lag-exporter-0.5.4.tgz
 ```
 
 #### Examples
@@ -141,7 +141,7 @@ Install with the [Strimzi](https://strimzi.io/) Kafka discovery feature.
 See [Strimzi Kafka Cluster Watcher](#strimzi-kafka-cluster-watcher) for more details.
 
 ```
-helm install https://github.com/lightbend/kafka-lag-exporter/releases/download/v0.5.5/kafka-lag-exporter-0.5.5.tgz \
+helm install https://github.com/lightbend/kafka-lag-exporter/releases/download/v0.5.4/kafka-lag-exporter-0.5.4.tgz \
   --name kafka-lag-exporter \
   --namespace kafka-lag-exporter \
   --set watchers.strimzi=true
@@ -150,7 +150,7 @@ helm install https://github.com/lightbend/kafka-lag-exporter/releases/download/v
 Install with statically defined cluster at the CLI.
 
 ```
-helm install https://github.com/lightbend/kafka-lag-exporter/releases/download/v0.5.5/kafka-lag-exporter-0.5.5.tgz \
+helm install https://github.com/lightbend/kafka-lag-exporter/releases/download/v0.5.4/kafka-lag-exporter-0.5.4.tgz \
   --name kafka-lag-exporter \
   --namespace myproject \
   --set clusters\[0\].name=my-cluster \
@@ -160,7 +160,7 @@ helm install https://github.com/lightbend/kafka-lag-exporter/releases/download/v
 Install with statically defined cluster at the CLI, but with a non-default service account assigned to the deployment.
 
 ```
-helm install https://github.com/lightbend/kafka-lag-exporter/releases/download/v0.5.5/kafka-lag-exporter-0.5.5.tgz \
+helm install https://github.com/lightbend/kafka-lag-exporter/releases/download/v0.5.4/kafka-lag-exporter-0.5.4.tgz \
   --name kafka-lag-exporter \
   --namespace myproject \
   --set clusters\[0\].name=my-cluster \
@@ -171,7 +171,7 @@ helm install https://github.com/lightbend/kafka-lag-exporter/releases/download/v
 Run a debug install (`DEBUG` logging, debug helm chart install, force docker pull policy to `Always`).
 
 ```
-helm install https://github.com/lightbend/kafka-lag-exporter/releases/download/v0.5.5/kafka-lag-exporter-0.5.5.tgz \
+helm install https://github.com/lightbend/kafka-lag-exporter/releases/download/v0.5.4/kafka-lag-exporter-0.5.4.tgz \
   --name kafka-lag-exporter \
   --namespace myproject \
   --set image.pullPolicy=Always \
@@ -282,7 +282,7 @@ Ex)
 ```
 docker run -p 8000:8000 \
     -v $(pwd):/opt/docker/conf/ \
-    lightbend/kafka-lag-exporter:0.5.5 \
+    lightbend/kafka-lag-exporter:0.5.4 \
     /opt/docker/bin/kafka-lag-exporter \
     -Dconfig.file=/opt/docker/conf/application.conf \
     -Dlogback.configurationFile=/opt/docker/conf/logback.xml

--- a/scripts/update_readme_version.sh
+++ b/scripts/update_readme_version.sh
@@ -13,5 +13,5 @@ echo helm install $RELEASE_URL
 sed -i -r "s/helm install http\S*/helm install ${RELEASE_URL_ESCAPED}/g" $DIR/../README.md
 
 echo Update README.md Running Docker Image version to:
-echo lightbend/kafka-lag-exporter:0.5.0
+echo lightbend/kafka-lag-exporter:${VERSION}
 sed -i -r "s/lightbend\/kafka-lag-exporter:\S*/lightbend\/kafka-lag-exporter:${VERSION}/g" $DIR/../README.md

--- a/src/main/scala/com/lightbend/kafkalagexporter/Metrics.scala
+++ b/src/main/scala/com/lightbend/kafkalagexporter/Metrics.scala
@@ -62,6 +62,12 @@ object Metrics {
     topicPartitionLabels
   )
 
+  val EarliestOffsetMetric = GaugeDefinition(
+    "kafka_partition_earliest_offset",
+    "Earliest offset of a partition",
+    topicPartitionLabels
+  )
+
   val groupLabels = List("cluster_name", "group")
 
   val MaxGroupOffsetLagMetric = GaugeDefinition(
@@ -98,6 +104,7 @@ object Metrics {
 
   val definitions = List(
     LatestOffsetMetric,
+    EarliestOffsetMetric,
     MaxGroupOffsetLagMetric,
     MaxGroupTimeLagMetric,
     LastGroupOffsetMetric,


### PR DESCRIPTION
kafka_partition_earliest_offset is now gathered and exported for all of the topic partitions which had been gathering the latest offset. Closes #67 