### PR TITLE
Upgrade Deployment apiversion to v1/apps

### DIFF
--- a/charts/kafka-lag-exporter/templates/040-Deployment.yaml
+++ b/charts/kafka-lag-exporter/templates/040-Deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "kafka-lag-exporter.fullname" . }}


### PR DESCRIPTION
`Deployment` is no longer part of `apps/v1beta` in later releases.