### PR TITLE
[helm chart] Template Out ServiceMonitor interval & scrapeTimeout

### DIFF
--- a/charts/kafka-lag-exporter/templates/060-ServiceMonitor.yaml
+++ b/charts/kafka-lag-exporter/templates/060-ServiceMonitor.yaml
@@ -19,5 +19,8 @@ spec:
     - {{ .Release.Namespace }}
   endpoints:
   - port: http
-    interval: 30
+    interval: {{ .Values.prometheus.serviceMonitor.interval }}
+    {{- if .Values.prometheus.serviceMonitor.scrapeTimeout }}
+    scrapeTimeout: {{ .Values.prometheus.serviceMonitor.scrapeTimeout }}
+    {{- end }}
 {{- end }}

--- a/charts/kafka-lag-exporter/values.yaml
+++ b/charts/kafka-lag-exporter/values.yaml
@@ -87,3 +87,4 @@ affinity: {}
 prometheus:
   serviceMonitor:
     enabled: false
+    interval: 30


### PR DESCRIPTION
Update helm chart to template out Prometheus ServiceMonitor `interval` & `scrapeTimeout`.