### PR TITLE
Template Service Monitor Namespace & Labels

### DIFF
--- a/charts/kafka-lag-exporter/Chart.yaml
+++ b/charts/kafka-lag-exporter/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 appVersion: "0.5.5-SNAPSHOT"
 description: Kafka Lag Exporter
 name: kafka-lag-exporter
-version: 0.5.5
+version: 0.5.6
 maintainers:
 - name: Sean Glover

--- a/charts/kafka-lag-exporter/Chart.yaml
+++ b/charts/kafka-lag-exporter/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 appVersion: "0.5.5-SNAPSHOT"
 description: Kafka Lag Exporter
 name: kafka-lag-exporter
-version: 0.5.6
+version: 0.5.5
 maintainers:
 - name: Sean Glover

--- a/charts/kafka-lag-exporter/templates/060-ServiceMonitor.yaml
+++ b/charts/kafka-lag-exporter/templates/060-ServiceMonitor.yaml
@@ -3,11 +3,17 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "kafka-lag-exporter.fullname" . }}
+  {{- if .Values.prometheus.serviceMonitor.namespace }}
+  namespace: {{ .Values.prometheus.serviceMonitor.namespace }}
+  {{- end }}
   labels:
     app.kubernetes.io/name: {{ include "kafka-lag-exporter.name" . }}
     helm.sh/chart: {{ include "kafka-lag-exporter.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- if .Values.prometheus.serviceMonitor.additionalLabels }}
+{{ toYaml .Values.prometheus.serviceMonitor.additionalLabels | indent 4 -}}
+    {{- end }}
 spec:
   jobLabel: jobLabel
   selector:

--- a/charts/kafka-lag-exporter/values.yaml
+++ b/charts/kafka-lag-exporter/values.yaml
@@ -88,3 +88,4 @@ prometheus:
   serviceMonitor:
     enabled: false
     interval: 30
+

--- a/charts/kafka-lag-exporter/values.yaml
+++ b/charts/kafka-lag-exporter/values.yaml
@@ -88,4 +88,7 @@ prometheus:
   serviceMonitor:
     enabled: false
     interval: 30
+    # service monitor label selectors: https://github.com/helm/charts/blob/f5a751f174263971fafd21eee4e35416d6612a3d/stable/prometheus-operator/templates/prometheus/prometheus.yaml#L74
+    # additionalLabels:
+    #   prometheus: k8s
 


### PR DESCRIPTION
Make the ServiceMonitor Namespace & Labels configurable.

This MR makes configuring prometheus auto discovery easier for the
following things:
* Generally, the ServiceMonitors may be in a separate namespace (the one
in which prometheus is deployed).
* Prometheus only discovers ServiceMonitors that have certain labels on them.

Also bumped helm chart patch version.