### PR TITLE
Allow mounting extra configmaps in pod

### DIFF
--- a/charts/kafka-lag-exporter/templates/040-Deployment.yaml
+++ b/charts/kafka-lag-exporter/templates/040-Deployment.yaml
@@ -46,6 +46,12 @@ spec:
           volumeMounts:
             - name: config-volume
               mountPath: /opt/docker/conf/
+          {{- range .Values.extraConfigmapMounts }}
+            - name: {{ .name }}
+              mountPath: {{ .mountPath }}
+              subPath: {{ .subPath }}
+              readOnly: {{ .readOnly }}
+          {{- end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
     {{- with .Values.nodeSelector }}
@@ -64,3 +70,8 @@ spec:
         - name: config-volume
           configMap:
             name: {{ include "kafka-lag-exporter.fullname" . }}-configmap
+      {{- range .Values.extraConfigmapMounts }}
+        - name: {{ .name }}
+          configMap:
+            name: {{ .configMap }}
+      {{- end }}

--- a/charts/kafka-lag-exporter/values.yaml
+++ b/charts/kafka-lag-exporter/values.yaml
@@ -83,6 +83,12 @@ resources: {}
 nodeSelector: {}
 tolerations: []
 affinity: {}
+extraConfigmapMounts: []
+  # - name: cacerts
+  #   configMap: cacerts-configmap
+  #   mountPath: /etc/pki/ca-trust/extracted/java/cacerts
+  #   subPath: ca-bundle.jks
+  #   readOnly: true
 
 prometheus:
   serviceMonitor:


### PR DESCRIPTION
Support mounting extra configmaps in pods. This can e.g. be used to provide a truststore if needed for TLS enabled clusters.