### PR TITLE
Fixing minor typo in helm chart

### DIFF
--- a/charts/kafka-lag-exporter/templates/040-Deployment.yaml
+++ b/charts/kafka-lag-exporter/templates/040-Deployment.yaml
@@ -15,7 +15,7 @@ spec:
       app.kubernetes.io/instance: {{ .Release.Name }}
       {{- if .Values.podAnnotations }}
       annotations:
-{{ toYaml .Value.podAnnotations | indent 8 }}
+{{ toYaml .Values.podAnnotations | indent 8 }}
       {{- end }}
   template:
     metadata:


### PR DESCRIPTION
Sorry about that, this change will fix the following error:
`Error: render error in "kafka-lag-exporter/templates/040-Deployment.yaml": template: kafka-lag-exporter/templates/040-Deployment.yaml:18:16: executing "kafka-lag-exporter/templates/040-Deployment.yaml" at <.Value.podAnnotations>: nil pointer evaluating interface {}.podAnnotations`