### PR TITLE
Helm Chart: Fix ServiceMonitor Interval Type To String

### DIFF
--- a/charts/kafka-lag-exporter/values.yaml
+++ b/charts/kafka-lag-exporter/values.yaml
@@ -105,7 +105,7 @@ podAnnotations: {}
 prometheus:
   serviceMonitor:
     enabled: false
-    interval: 30
+    interval: "30s"
     # service monitor label selectors: https://github.com/helm/charts/blob/f5a751f174263971fafd21eee4e35416d6612a3d/stable/prometheus-operator/templates/prometheus/prometheus.yaml#L74
     # additionalLabels:
     #   prometheus: k8s


### PR DESCRIPTION
Fix _prometheus.serviceMonitor.interval_ type from integer to string in the default values.
Otherwise enabling ServiceMonitor in the helm chart results in an error like this:
```
Error: release kafka-lag-exporter failed: ServiceMonitor.monitoring.coreos.com "kafka-lag-exporter" is invalid: []: Invalid value: map[string]interface {}{"kind":"ServiceMonitor", "metadata":map[string]interface {}{"generation":1, "uid":"76063bad-0cf5-11ea-8416-0cc47a338560", "name":"kafka-lag-exporter", "namespace":"monitoring", "creationTimestamp":"2019-11-22T06:58:17Z", "labels":map[string]interface {}{"app":"kafka-lag-exporter", "app.kubernetes.io/instance":"kafka-lag-exporter", "app.kubernetes.io/managed-by":"Tiller", "app.kubernetes.io/name":"kafka-lag-exporter", "helm.sh/chart":"kafka-lag-exporter-0.5.6"}}, "spec":map[string]interface {}{"endpoints":[]interface {}{map[string]interface {}{"port":"http", "interval":30}}, "jobLabel":"jobLabel", "namespaceSelector":map[string]interface {}{"matchNames":[]interface {}{"centrallogging"}}, "selector":map[string]interface {}{"matchLabels":map[string]interface {}{"app.kubernetes.io/name":"kafka-lag-exporter", "helm.sh/chart":"kafka-lag-exporter-0.5.6"}}}, "apiVersion":"monitoring.coreos.com/v1"}: validation failure list:
spec.endpoints.interval in body must be of type string: "integer"
```
Reference: https://github.com/coreos/prometheus-operator/blob/60300f2baf8b02bc86d71672a76420476924af75/example/prometheus-operator-crd/servicemonitor.crd.yaml#L103