### PR TITLE
Bypass prediction when consumer group is caught up

### DIFF
--- a/src/main/scala/com/lightbend/kafkalagexporter/LookupTable.scala
+++ b/src/main/scala/com/lightbend/kafkalagexporter/LookupTable.scala
@@ -73,13 +73,10 @@ object LookupTable {
       }
 
       points.toList match {
+        // lag is zero if offset matches the last offset on the topic
+        case p if !p.isEmpty && p.last.offset == offset => LagIsZero
         case p if p.length < 2 => TooFewPoints
-        // if we only have 2 points the same as the current offset then report
-        // lag as zero
-        case p1 :: p2 :: Nil if p1.offset == p2.offset &&
-                                p2.offset == offset => LagIsZero
         case _ => estimate()
-
       }
     }
 

--- a/src/test/scala/com/lightbend/kafkalagexporter/LookupTableSpec.scala
+++ b/src/test/scala/com/lightbend/kafkalagexporter/LookupTableSpec.scala
@@ -89,6 +89,14 @@ class LookupTableSpec extends FreeSpec with Matchers {
         table.lookup(0) shouldBe LagIsZero
       }
 
+      "lookups when table has a single element same as lookup" in {
+        val table = Table(5)
+
+        table.addPoint(Point(0, 100))
+
+        table.lookup(0) shouldBe LagIsZero
+      }
+
       "infinite lookups, dy == 0, flat curve/no growth" in {
         val table = Table(10)
 
@@ -138,7 +146,7 @@ class LookupTableSpec extends FreeSpec with Matchers {
         table.lookup(2999) shouldBe Prediction(2.9996428571428573)
         table.lookup(3000) shouldBe Prediction(3)
         table.lookup(3001) shouldBe Prediction(3.000027027027027)
-        table.lookup(40000) shouldBe Prediction(4)
+        table.lookup(40000) shouldBe LagIsZero
         // extrapolation
         table.lookup(-10000) shouldBe Prediction(-1)
         table.lookup(50000) shouldBe Prediction(5)


### PR DESCRIPTION
Resolves #111 

If the offset committed by the consumer group matches the latest offset on the partition, bypass prediction entirely and report lag of zero.

Previously, if you had a lookup table that looked like this:

```
Offset: 1, Timestamp: 1
Offset: 2, Timestamp: 2
Offset: 2, Timestamp: 3
```

The logic was attempting to run a prediction that resulted in `NaN`