### PR TITLE
Add graphite support

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,20 +224,32 @@ To run the project in standalone mode you must first define a configuration `app
 contain at least connection info to your Kafka cluster (`kafka-lag-exporter.clusters`). All other configuration has
 defaults defined in the project itself.  See [`reference.conf`](./src/main/resources/reference.conf) for defaults.
 
+### Reporters
+
+It is possible to report (either or both):
+
+  - to graphite via the config `kafka-lag-exporter.reporters.graphite`
+  - as prometheus via the config `kafka-lag-exporter.reporters.prometheus`
+
+See section below for more information.
+
 ### Configuration
 
 General Configuration (`kafka-lag-exporter{}`)
 
-| Key                           | Default            | Description                                                                                                                           |
-|-------------------------------|--------------------|---------------------------------------------------------------------------------------------------------------------------------------|
-| `port`                        | `8000`             | The port to run the Prometheus endpoint on                                                                                            |
-| `poll-interval`               | `30 seconds`       | How often to poll Kafka for latest and group offsets                                                                                  |
-| `lookup-table-size`           | `60`               | The maximum window size of the look up table **per partition**                                                                        |
-| `client-group-id`             | `kafkalagexporter` | Consumer group id of kafka-lag-exporter's client connections                                                                          |
-| `kafka-client-timeout`        | `10 seconds`       | Connection timeout when making API calls to Kafka                                                                                     |
-| `clusters`                    | `[]`               | A statically defined list of Kafka connection details.  This list is optional if you choose to use the Strimzi auto-discovery feature |
-| `watchers`                    | `{}`               | Settings for Kafka cluster "watchers" used for auto-discovery.                                                                        |
-| `metric-whitelist`            | `[".*"]`           | Regex of metrics to be exposed via Prometheus endpoint. Eg. `[".*_max_lag.*", "kafka_partition_latest_offset"]`                       |
+| Key                         | Default            | Description                                                                                                                           |
+|-----------------------------|--------------------|---------------------------------------------------------------------------------------------------------------------------------------|
+| `reporters.prometheus.port` | `8000`             | The port to run the Prometheus endpoint on                                                                                            |
+| `reporters.graphite.host`   | None               | The graphite host to send metrics to (if not set, will not output to grahpite)                                                        |
+| `reporters.graphite.port`   | None               | The graphite port to send metrics to (if not set, will not output to graphite)                                                        |
+| `reporters.graphite.prefix` | None               | The graphite metric prefix (if not set, prefix will be embty)                                                                         |
+| `poll-interval`             | `30 seconds`       | How often to poll Kafka for latest and group offsets                                                                                  |
+| `lookup-table-size`         | `60`               | The maximum window size of the look up table **per partition**                                                                        |
+| `client-group-id`           | `kafkalagexporter` | Consumer group id of kafka-lag-exporter's client connections                                                                          |
+| `kafka-client-timeout`      | `10 seconds`       | Connection timeout when making API calls to Kafka                                                                                     |
+| `clusters`                  | `[]`               | A statically defined list of Kafka connection details.  This list is optional if you choose to use the Strimzi auto-discovery feature |
+| `watchers`                  | `{}`               | Settings for Kafka cluster "watchers" used for auto-discovery.                                                                        |
+| `metric-whitelist`          | `[".*"]`           | Regex of metrics to be exposed via Prometheus endpoint. Eg. `[".*_max_lag.*", "kafka_partition_latest_offset"]`                       |
 
 Kafka Cluster Connection Details (`kafka-lag-exporter.clusters[]`)
 
@@ -264,7 +276,11 @@ and `AdminClient` used by the project.
 
 ```
 kafka-lag-exporter {
-  port = 9999
+  reporters {
+    prometheus {
+      port = 9999
+    }
+  }
   lookup-table-size = 120
   clusters = [
     {

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
   - [View the health endpoint](#view-the-health-endpoint)
     - [View exporter logs](#view-exporter-logs)
 - [Run Standalone](#run-standalone)
+  - [Reporters](#reporters)
   - [Configuration](#configuration-1)
   - [Running Docker Image](#running-docker-image)
 - [Estimate Consumer Group Time Lag](#estimate-consumer-group-time-lag)
@@ -240,9 +241,9 @@ General Configuration (`kafka-lag-exporter{}`)
 | Key                         | Default            | Description                                                                                                                           |
 |-----------------------------|--------------------|---------------------------------------------------------------------------------------------------------------------------------------|
 | `reporters.prometheus.port` | `8000`             | The port to run the Prometheus endpoint on                                                                                            |
-| `reporters.graphite.host`   | None               | The graphite host to send metrics to (if not set, will not output to grahpite)                                                        |
+| `reporters.graphite.host`   | None               | The graphite host to send metrics to (if not set, will not output to graphite)                                                        |
 | `reporters.graphite.port`   | None               | The graphite port to send metrics to (if not set, will not output to graphite)                                                        |
-| `reporters.graphite.prefix` | None               | The graphite metric prefix (if not set, prefix will be embty)                                                                         |
+| `reporters.graphite.prefix` | None               | The graphite metric prefix (if not set, prefix will be empty)                                                                         |
 | `poll-interval`             | `30 seconds`       | How often to poll Kafka for latest and group offsets                                                                                  |
 | `lookup-table-size`         | `60`               | The maximum window size of the look up table **per partition**                                                                        |
 | `client-group-id`           | `kafkalagexporter` | Consumer group id of kafka-lag-exporter's client connections                                                                          |

--- a/examples/standalone/application.conf
+++ b/examples/standalone/application.conf
@@ -1,5 +1,5 @@
 kafka-lag-exporter {
-  port = 8000
+  reporters.prometheus.port = 8000
   clusters = [
     {
       name = "a-cluster"

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1,6 +1,6 @@
 kafka-lag-exporter {
-  port = 8000
-  port = ${?KAFKA_LAG_EXPORTER_PORT}
+  reporters.prometheus.port = 8000
+  reporters.prometheus.port = ${?KAFKA_LAG_EXPORTER_PORT}
   poll-interval = 30 seconds
   poll-interval = ${?KAFKA_LAG_EXPORTER_POLL_INTERVAL_SECONDS}
   lookup-table-size = 60

--- a/src/main/scala/com/lightbend/kafkalagexporter/AppConfig.scala
+++ b/src/main/scala/com/lightbend/kafkalagexporter/AppConfig.scala
@@ -6,7 +6,7 @@ package com.lightbend.kafkalagexporter
 
 import java.util
 
-import com.lightbend.kafkalagexporter.PrometheusEndpointSink.ClusterGlobalLabels
+import com.lightbend.kafkalagexporter.EndpointSink.ClusterGlobalLabels
 import com.typesafe.config.{Config, ConfigObject}
 
 import scala.annotation.tailrec
@@ -21,7 +21,8 @@ object AppConfig {
     val graphiteConfig: Option[GraphiteConfig] = (
       for (host <- Try(c.getString("graphite-host"));
            port <- Try(c.getInt("graphite-port")),
-             ) yield GraphiteConfig(host, port)).toOption
+             ) yield GraphiteConfig(
+               host, port, Try(c.getString("graphite-prefix")).toOption)).toOption
     val pollInterval = c.getDuration("poll-interval").toScala
     val lookupTableSize = c.getInt("lookup-table-size")
     val port = c.getInt("port")
@@ -133,6 +134,7 @@ final case class AppConfig(pollInterval: FiniteDuration, lookupTableSize: Int, p
         |Graphite: 
         |  host: ${graphite.host}
         |  port: ${graphite.port}
+        |  prefix: ${graphite.prefix}
         """.stripMargin }.getOrElse("")
     val clusterString =
       if (clusters.isEmpty)

--- a/src/main/scala/com/lightbend/kafkalagexporter/AppConfig.scala
+++ b/src/main/scala/com/lightbend/kafkalagexporter/AppConfig.scala
@@ -19,13 +19,15 @@ object AppConfig {
   def apply(config: Config): AppConfig = {
     val c = config.getConfig("kafka-lag-exporter")
     val graphiteConfig: Option[GraphiteConfig] = (
-      for (host <- Try(c.getString("graphite-host"));
-           port <- Try(c.getInt("graphite-port")),
+      for (host <- Try(c.getString("reporters.graphite.host"));
+           port <- Try(c.getInt("reporters.graphite.port")),
              ) yield GraphiteConfig(
-               host, port, Try(c.getString("graphite-prefix")).toOption)).toOption
+               host, port, Try(c.getString("reporters.graphite.prefix")).toOption)).toOption
     val pollInterval = c.getDuration("poll-interval").toScala
     val lookupTableSize = c.getInt("lookup-table-size")
-    val port = c.getInt("port")
+    val prometheusPortLegacy = Try(c.getInt("port")).toOption
+    val prometheusPortNew = Try(c.getInt("reporters.prometheus.port")).toOption
+    val prometheusConfig = (prometheusPortNew orElse prometheusPortLegacy).map { port => PrometheusConfig(port) }
     val clientGroupId = c.getString("client-group-id")
     val kafkaClientTimeout = c.getDuration("kafka-client-timeout").toScala
     val clusters = c.getConfigList("clusters").asScala.toList.map { clusterConfig =>
@@ -72,7 +74,7 @@ object AppConfig {
     }
     val strimziWatcher = c.getString("watchers.strimzi").toBoolean
     val metricWhitelist = c.getStringList("metric-whitelist").asScala.toList
-    AppConfig(pollInterval, lookupTableSize, port, clientGroupId, kafkaClientTimeout, clusters, strimziWatcher, metricWhitelist, graphiteConfig)
+    AppConfig(pollInterval, lookupTableSize, clientGroupId, kafkaClientTimeout, clusters, strimziWatcher, metricWhitelist, prometheusConfig, graphiteConfig)
   }
 
   // Copied from Alpakka Kafka
@@ -125,9 +127,11 @@ final case class KafkaCluster(name: String, bootstrapBrokers: String,
      """.stripMargin
   }
 }
-final case class AppConfig(pollInterval: FiniteDuration, lookupTableSize: Int, port: Int, clientGroupId: String,
+final case class AppConfig(pollInterval: FiniteDuration, lookupTableSize: Int, clientGroupId: String,
                            clientTimeout: FiniteDuration, clusters: List[KafkaCluster], strimziWatcher: Boolean,
-                           metricWhitelist: List[String], graphiteConfig: Option[GraphiteConfig]) {
+                           metricWhitelist: List[String],
+                           prometheusConfig: Option[PrometheusConfig],
+                           graphiteConfig: Option[GraphiteConfig]) {
   override def toString(): String = {
     val graphiteString =
       graphiteConfig.map { graphite => s"""
@@ -136,6 +140,11 @@ final case class AppConfig(pollInterval: FiniteDuration, lookupTableSize: Int, p
         |  port: ${graphite.port}
         |  prefix: ${graphite.prefix}
         """.stripMargin }.getOrElse("")
+    val prometheusString =
+      prometheusConfig.map { prometheus => s"""
+        |Prometheus: 
+        |  port: ${prometheus.port}
+        """.stripMargin }.getOrElse("")
     val clusterString =
       if (clusters.isEmpty)
         "  (none)"
@@ -143,10 +152,10 @@ final case class AppConfig(pollInterval: FiniteDuration, lookupTableSize: Int, p
     s"""
        |Poll interval: $pollInterval
        |Lookup table size: $lookupTableSize
-       |Prometheus metrics endpoint port: $port
-       |Prometheus metrics whitelist: [${metricWhitelist.mkString(", ")}]
+       |Metrics whitelist: [${metricWhitelist.mkString(", ")}]
        |Admin client consumer group id: $clientGroupId
        |Kafka client timeout: $clientTimeout
+       |$prometheusString
        |$graphiteString
        |Statically defined Clusters:
        |$clusterString

--- a/src/main/scala/com/lightbend/kafkalagexporter/EndpointSink.scala
+++ b/src/main/scala/com/lightbend/kafkalagexporter/EndpointSink.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2019 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package com.lightbend.kafkalagexporter
+
+import com.lightbend.kafkalagexporter.EndpointSink.{ClusterGlobalLabels, ClusterName}
+import io.prometheus.client.hotspot.DefaultExports
+
+object EndpointSink {
+  type ClusterName = String
+  type GlobalLabels = Map[String, String]
+  type ClusterGlobalLabels = Map[ClusterName, GlobalLabels]
+}
+
+abstract class EndpointSink (clusterGlobalLabels: ClusterGlobalLabels) extends MetricsSink {
+  DefaultExports.initialize()
+
+  private[kafkalagexporter] val globalLabelNames: List[String] = {
+    clusterGlobalLabels.values.flatMap(_.keys).toList.distinct
+  }
+
+  def getGlobalLabelValuesOrDefault(clusterName: ClusterName): List[String] = {
+    val globalLabelValuesForCluster = clusterGlobalLabels.getOrElse(clusterName, Map.empty)
+    globalLabelNames.map(l => globalLabelValuesForCluster.getOrElse(l, ""))
+  }
+}
+

--- a/src/main/scala/com/lightbend/kafkalagexporter/GraphiteConfig.scala
+++ b/src/main/scala/com/lightbend/kafkalagexporter/GraphiteConfig.scala
@@ -4,4 +4,4 @@
 
 package com.lightbend.kafkalagexporter
 
-case class GraphiteConfig(host: String, port: Int)
+case class GraphiteConfig(host: String, port: Int, prefix: Option[String])

--- a/src/main/scala/com/lightbend/kafkalagexporter/GraphiteConfig.scala
+++ b/src/main/scala/com/lightbend/kafkalagexporter/GraphiteConfig.scala
@@ -1,0 +1,7 @@
+/*
+ * Copyright (C) 2019 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package com.lightbend.kafkalagexporter
+
+case class GraphiteConfig(host: String, port: Int)

--- a/src/main/scala/com/lightbend/kafkalagexporter/GraphiteEndpointSink.scala
+++ b/src/main/scala/com/lightbend/kafkalagexporter/GraphiteEndpointSink.scala
@@ -17,7 +17,7 @@ object GraphiteEndpointSink {
   def apply(metricWhitelist: List[String], clusterGlobalLabels: ClusterGlobalLabels,
             graphiteConfig: Option[GraphiteConfig]): MetricsSink = {
     Try(new GraphiteEndpointSink(metricWhitelist, clusterGlobalLabels, graphiteConfig))
-      .fold(t => throw new Exception("Could not create Prometheus Endpoint", t), sink => sink)
+      .fold(t => throw new Exception("Could not create Graphite Endpoint", t), sink => sink)
   }
 }
 
@@ -39,6 +39,12 @@ class GraphiteEndpointSink private(metricWhitelist: List[String], clusterGlobalL
     }
   }
 
+  /**
+    * get graphite metric name for a metric value
+    *
+    * @example { label1=value1, label2=value2, name=myName } => "value1.value2.myName"
+    *
+    */ 
   def metricNameToGraphiteMetricName(metricValue: MetricValue): String = {
     (getGlobalLabelValuesOrDefault(metricValue.clusterName) ++ metricValue.labels
       ).map( x => x.replaceAll("\\.", "_")).mkString(".") + "." + metricValue.definition.name;

--- a/src/main/scala/com/lightbend/kafkalagexporter/GraphiteEndpointSink.scala
+++ b/src/main/scala/com/lightbend/kafkalagexporter/GraphiteEndpointSink.scala
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2019 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package com.lightbend.kafkalagexporter
+
+import com.lightbend.kafkalagexporter.MetricsSink._
+import com.lightbend.kafkalagexporter.EndpointSink.ClusterGlobalLabels
+import java.net.Socket
+import java.io.PrintWriter
+import scala.util.{Try, Success, Failure}
+
+import scala.util.Try
+
+object GraphiteEndpointSink {
+
+  def apply(metricWhitelist: List[String], clusterGlobalLabels: ClusterGlobalLabels,
+            graphiteConfig: Option[GraphiteConfig]): MetricsSink = {
+    Try(new GraphiteEndpointSink(metricWhitelist, clusterGlobalLabels, graphiteConfig))
+      .fold(t => throw new Exception("Could not create Prometheus Endpoint", t), sink => sink)
+  }
+}
+
+class GraphiteEndpointSink private(metricWhitelist: List[String], clusterGlobalLabels: ClusterGlobalLabels,
+                                      graphiteConfig: Option[GraphiteConfig]) extends EndpointSink(clusterGlobalLabels) {
+  def graphitePush(graphiteConfig: GraphiteConfig, metricName: String, metricValue: Double): Unit = {
+    Try(new Socket(graphiteConfig.host, graphiteConfig.port)) match {
+      case Success(socket) =>
+        Try(new PrintWriter(socket.getOutputStream)) match {
+          case Success(writer) =>
+            writer.print(s"${graphiteConfig.prefix.getOrElse("")}${metricName} ${metricValue} ${System.currentTimeMillis / 1000}\n")
+            writer.close
+            socket.close
+          case Failure(_) =>
+            socket.close
+        }
+      case Failure(_) => {
+      }
+    }
+  }
+
+  def metricNameToGraphiteMetricName(metricValue: MetricValue): String = {
+    (getGlobalLabelValuesOrDefault(metricValue.clusterName) ++ metricValue.labels
+      ).map( x => x.replaceAll("\\.", "_")).mkString(".") + "." + metricValue.definition.name;
+  }
+
+  override def report(m: MetricValue): Unit = {
+    if (metricWhitelist.exists(m.definition.name.matches)) {
+      graphiteConfig.foreach { conf =>
+        graphitePush(conf, metricNameToGraphiteMetricName(m), m.value);
+      }
+    }
+  }
+
+  override def remove(m: RemoveMetric): Unit = {
+  }
+
+
+}
+

--- a/src/main/scala/com/lightbend/kafkalagexporter/KafkaClusterManager.scala
+++ b/src/main/scala/com/lightbend/kafkalagexporter/KafkaClusterManager.scala
@@ -21,12 +21,14 @@ object KafkaClusterManager {
   final case object Done extends Done
   final case class ClusterAdded(c: KafkaCluster) extends Message
   final case class ClusterRemoved(c: KafkaCluster) extends Message
+  final case class NamedCreator(name: String, creator: () => MetricsSink)
+
 
   private val stopTimeout: Timeout = 3.seconds
 
   def init(
             appConfig: AppConfig,
-            metricsSink: () => MetricsSink,
+            metricsSinks: List[NamedCreator],
             clientCreator: KafkaCluster => KafkaClientContract): Behavior[Message] = Behaviors.setup { context =>
 
     context.log.info("Starting Kafka Lag Exporter with configuration: \n{}", appConfig)
@@ -34,20 +36,21 @@ object KafkaClusterManager {
     if (appConfig.clusters.isEmpty && !appConfig.strimziWatcher)
       context.log.info("No watchers are defined and no clusters are statically configured.  Nothing to do.")
 
-    val metricsSinkInst: MetricsSink = metricsSink()
     val watchers: Seq[ActorRef[Watcher.Message]] = Watcher.createClusterWatchers(context, appConfig)
-    val reporter: ActorRef[MetricsSink.Message] = context.spawn(MetricsReporter.init(metricsSinkInst), "lag-reporter")
+    val reporters: List[ActorRef[MetricsSink.Message]] = metricsSinks.map { metricsSink : NamedCreator =>
+      context.spawn(MetricsReporter.init(metricsSink.creator()), metricsSink.name)
+    }
     appConfig.clusters.foreach(cluster => context.self ! ClusterAdded(cluster))
 
-    context.watch(reporter)
+    reporters.map { context.watch }
 
-    manager(appConfig, clientCreator, reporter, collectors = Map.empty, watchers)
+    manager(appConfig, clientCreator, reporters, collectors = Map.empty, watchers)
   }
 
   def manager(
                appConfig: AppConfig,
                clientCreator: KafkaCluster => KafkaClientContract,
-               reporter: ActorRef[MetricsSink.Message],
+               reporters: List[ActorRef[MetricsSink.Message]],
                collectors: Map[KafkaCluster, ActorRef[ConsumerGroupCollector.Message]],
                watchers: Seq[ActorRef[Watcher.Message]]): Behavior[Message] =
     Behaviors.receive[Message] {
@@ -60,11 +63,11 @@ object KafkaClusterManager {
           cluster
         )
         val collector = context.spawn(
-          ConsumerGroupCollector.init(config, clientCreator, reporter),
+          ConsumerGroupCollector.init(config, clientCreator, reporters),
           s"consumer-group-collector-${cluster.name}"
         )
 
-        manager(appConfig, clientCreator, reporter, collectors + (cluster -> collector), watchers)
+        manager(appConfig, clientCreator, reporters, collectors + (cluster -> collector), watchers)
 
       case (context, ClusterRemoved(cluster)) =>
         context.log.info(s"Cluster Removed: $cluster")
@@ -72,9 +75,9 @@ object KafkaClusterManager {
         collectors.get(cluster) match {
           case Some(collector) =>
             collector ! ConsumerGroupCollector.Stop
-            manager(appConfig, clientCreator, reporter, collectors - cluster, watchers)
+            manager(appConfig, clientCreator, reporters, collectors - cluster, watchers)
           case None =>
-            manager(appConfig, clientCreator, reporter, collectors, watchers)
+            manager(appConfig, clientCreator, reporters, collectors, watchers)
         }
 
       case (context, _: Stop) =>
@@ -82,17 +85,19 @@ object KafkaClusterManager {
         watchers.foreach(_ ! Watcher.Stop)
         collectors.foreach { case (_, collector) => collector ! ConsumerGroupCollector.Stop }
         implicit val timeout = stopTimeout
-        context.ask(reporter, (_: ActorRef[MetricsSink.Message]) => MetricsSink.Stop(context.self)) {
-          case Success(_) => Done
-          case Failure(ex) =>
-            context.log.error("The metrics reporter shutdown failed.", ex)
-            Done
+        reporters.foreach { reporter =>
+          context.ask(reporter, (_: ActorRef[MetricsSink.Message]) => MetricsSink.Stop(context.self)) {
+            case Success(_) => Done
+            case Failure(ex) =>
+              context.log.error("The metrics reporter shutdown failed.", ex)
+              Done
+          }
         }
         Behaviors.same
       case (_, _: Done) =>
         Behaviors.stopped
     } receiveSignal {
-      case (context, ChildFailed(`reporter`, cause)) =>
+      case (context, ChildFailed(`reporters`, cause)) =>
         context.log.error("The metrics reporter failed.  Shutting down.", cause)
         context.self ! Stop
         Behaviors.same

--- a/src/main/scala/com/lightbend/kafkalagexporter/MainApp.scala
+++ b/src/main/scala/com/lightbend/kafkalagexporter/MainApp.scala
@@ -31,19 +31,22 @@ object MainApp extends App {
 
     val clientCreator = (cluster: KafkaCluster) =>
       KafkaClient(cluster, appConfig.clientGroupId, appConfig.clientTimeout)(kafkaClientEc)
-    val server = new HTTPServer(appConfig.port)
-    val endpointCreators = List(
-      KafkaClusterManager.NamedCreator(
+    var endpointCreators : List[KafkaClusterManager.NamedCreator] = List()
+    appConfig.prometheusConfig.foreach { prometheus =>
+      val prometheusCreator = KafkaClusterManager.NamedCreator(
         "prometheus-lag-reporter", 
         (() => PrometheusEndpointSink(
-          Metrics.definitions, appConfig.metricWhitelist, appConfig.clustersGlobalLabels(), server, CollectorRegistry.defaultRegistry
+          Metrics.definitions, appConfig.metricWhitelist, appConfig.clustersGlobalLabels(), new HTTPServer(prometheus.port), CollectorRegistry.defaultRegistry
         ))
-      ),
-      KafkaClusterManager.NamedCreator(
-        "graphite-lag-reporter",
-        (() => GraphiteEndpointSink(appConfig.metricWhitelist, appConfig.clustersGlobalLabels(), appConfig.graphiteConfig))
       )
-    )
+      endpointCreators = prometheusCreator :: endpointCreators
+    }
+    appConfig.graphiteConfig.foreach { _ =>
+      val graphiteCreator = KafkaClusterManager.NamedCreator(
+        "graphite-lag-reporter",
+        (() => GraphiteEndpointSink(appConfig.metricWhitelist, appConfig.clustersGlobalLabels(), appConfig.graphiteConfig)))
+      endpointCreators = graphiteCreator :: endpointCreators
+    }
     ActorSystem(
       KafkaClusterManager.init(appConfig, endpointCreators, clientCreator), "kafka-lag-exporter")
   }

--- a/src/main/scala/com/lightbend/kafkalagexporter/MainApp.scala
+++ b/src/main/scala/com/lightbend/kafkalagexporter/MainApp.scala
@@ -33,7 +33,8 @@ object MainApp extends App {
       KafkaClient(cluster, appConfig.clientGroupId, appConfig.clientTimeout)(kafkaClientEc)
     val server = new HTTPServer(appConfig.port)
     val endpointCreator = () => PrometheusEndpointSink(Metrics.definitions, appConfig.metricWhitelist,
-      appConfig.clustersGlobalLabels(), server, CollectorRegistry.defaultRegistry)
+      appConfig.clustersGlobalLabels(), server, CollectorRegistry.defaultRegistry,
+      appConfig.graphiteConfig)
 
     ActorSystem(
       KafkaClusterManager.init(appConfig, endpointCreator, clientCreator), "kafka-lag-exporter")

--- a/src/main/scala/com/lightbend/kafkalagexporter/PrometheusConfig.scala
+++ b/src/main/scala/com/lightbend/kafkalagexporter/PrometheusConfig.scala
@@ -1,0 +1,8 @@
+/*
+ * Copyright (C) 2019 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package com.lightbend.kafkalagexporter
+
+case class PrometheusConfig(port: Int)
+

--- a/src/main/scala/com/lightbend/kafkalagexporter/PrometheusEndpointSink.scala
+++ b/src/main/scala/com/lightbend/kafkalagexporter/PrometheusEndpointSink.scala
@@ -9,6 +9,9 @@ import com.lightbend.kafkalagexporter.PrometheusEndpointSink.{ClusterGlobalLabel
 import io.prometheus.client.exporter.HTTPServer
 import io.prometheus.client.hotspot.DefaultExports
 import io.prometheus.client.{CollectorRegistry, Gauge}
+import java.net.Socket
+import java.io.PrintWriter
+import scala.util.{Try, Success, Failure}
 
 import scala.util.Try
 
@@ -19,14 +22,14 @@ object PrometheusEndpointSink {
   type Metrics = Map[GaugeDefinition, Gauge]
 
   def apply(definitions: MetricDefinitions, metricWhitelist: List[String], clusterGlobalLabels: ClusterGlobalLabels,
-            server: HTTPServer, registry: CollectorRegistry): MetricsSink = {
-    Try(new PrometheusEndpointSink(definitions, metricWhitelist, clusterGlobalLabels, server, registry))
+            server: HTTPServer, registry: CollectorRegistry, graphiteConfig: Option[GraphiteConfig]): MetricsSink = {
+    Try(new PrometheusEndpointSink(definitions, metricWhitelist, clusterGlobalLabels, server, registry, graphiteConfig))
       .fold(t => throw new Exception("Could not create Prometheus Endpoint", t), sink => sink)
   }
 }
 
 class PrometheusEndpointSink private(definitions: MetricDefinitions, metricWhitelist: List[String], clusterGlobalLabels: ClusterGlobalLabels,
-                                     server: HTTPServer, registry: CollectorRegistry) extends MetricsSink {
+                                     server: HTTPServer, registry: CollectorRegistry, graphiteConfig: Option[GraphiteConfig]) extends MetricsSink {
   DefaultExports.initialize()
 
   private[kafkalagexporter] val globalLabelNames: List[String] = {
@@ -43,10 +46,34 @@ class PrometheusEndpointSink private(definitions: MetricDefinitions, metricWhite
     }.toMap
   }
 
+  def graphitePush(graphiteConfig: GraphiteConfig, metricName: String, metricValue: Double): Unit = {
+    Try(new Socket(graphiteConfig.host, graphiteConfig.port)) match {
+      case Success(socket) =>
+        Try(new PrintWriter(socket.getOutputStream)) match {
+          case Success(writer) =>
+            writer.print(s"${metricName} ${metricValue} ${System.currentTimeMillis / 1000}\n")
+            writer.close
+            socket.close
+          case Failure(_) =>
+            socket.close
+        }
+      case Failure(_) => {
+      }
+    }
+  }
+
+  def phometheusMetricNameToGraphiteMetricName(metricValue: MetricValue): String = {
+    (getGlobalLabelValuesOrDefault(metricValue.clusterName) ++ metricValue.labels
+      ).map( x => x.replaceAll("\\.", "_")).mkString(".") + "." + metricValue.definition.name;
+  }
+
   override def report(m: MetricValue): Unit = {
     if (metricWhitelist.exists(m.definition.name.matches)) {
       val metric = metrics.getOrElse(m.definition, throw new IllegalArgumentException(s"No metric with definition ${m.definition.name} registered"))
       metric.labels(getGlobalLabelValuesOrDefault(m.clusterName) ++ m.labels: _*).set(m.value)
+      graphiteConfig.foreach { conf =>
+        graphitePush(conf, phometheusMetricNameToGraphiteMetricName(m), m.value);
+      }
     }
   }
 

--- a/src/main/scala/com/lightbend/kafkalagexporter/PrometheusEndpointSink.scala
+++ b/src/main/scala/com/lightbend/kafkalagexporter/PrometheusEndpointSink.scala
@@ -5,36 +5,27 @@
 package com.lightbend.kafkalagexporter
 
 import com.lightbend.kafkalagexporter.MetricsSink._
-import com.lightbend.kafkalagexporter.PrometheusEndpointSink.{ClusterGlobalLabels, ClusterName, Metrics}
+import com.lightbend.kafkalagexporter.EndpointSink.ClusterGlobalLabels
+import com.lightbend.kafkalagexporter.PrometheusEndpointSink.Metrics
 import io.prometheus.client.exporter.HTTPServer
 import io.prometheus.client.hotspot.DefaultExports
 import io.prometheus.client.{CollectorRegistry, Gauge}
-import java.net.Socket
-import java.io.PrintWriter
-import scala.util.{Try, Success, Failure}
 
 import scala.util.Try
 
 object PrometheusEndpointSink {
-  type ClusterName = String
-  type GlobalLabels = Map[String, String]
-  type ClusterGlobalLabels = Map[ClusterName, GlobalLabels]
   type Metrics = Map[GaugeDefinition, Gauge]
 
   def apply(definitions: MetricDefinitions, metricWhitelist: List[String], clusterGlobalLabels: ClusterGlobalLabels,
-            server: HTTPServer, registry: CollectorRegistry, graphiteConfig: Option[GraphiteConfig]): MetricsSink = {
-    Try(new PrometheusEndpointSink(definitions, metricWhitelist, clusterGlobalLabels, server, registry, graphiteConfig))
+            server: HTTPServer, registry: CollectorRegistry): MetricsSink = {
+    Try(new PrometheusEndpointSink(definitions, metricWhitelist, clusterGlobalLabels, server, registry))
       .fold(t => throw new Exception("Could not create Prometheus Endpoint", t), sink => sink)
   }
 }
 
 class PrometheusEndpointSink private(definitions: MetricDefinitions, metricWhitelist: List[String], clusterGlobalLabels: ClusterGlobalLabels,
-                                     server: HTTPServer, registry: CollectorRegistry, graphiteConfig: Option[GraphiteConfig]) extends MetricsSink {
+                                     server: HTTPServer, registry: CollectorRegistry) extends EndpointSink(clusterGlobalLabels) {
   DefaultExports.initialize()
-
-  private[kafkalagexporter] val globalLabelNames: List[String] = {
-    clusterGlobalLabels.values.flatMap(_.keys).toList.distinct
-  }
 
   private val metrics: Metrics = {
     definitions.filter(d => metricWhitelist.exists(d.name.matches)).map { d =>
@@ -46,34 +37,10 @@ class PrometheusEndpointSink private(definitions: MetricDefinitions, metricWhite
     }.toMap
   }
 
-  def graphitePush(graphiteConfig: GraphiteConfig, metricName: String, metricValue: Double): Unit = {
-    Try(new Socket(graphiteConfig.host, graphiteConfig.port)) match {
-      case Success(socket) =>
-        Try(new PrintWriter(socket.getOutputStream)) match {
-          case Success(writer) =>
-            writer.print(s"${metricName} ${metricValue} ${System.currentTimeMillis / 1000}\n")
-            writer.close
-            socket.close
-          case Failure(_) =>
-            socket.close
-        }
-      case Failure(_) => {
-      }
-    }
-  }
-
-  def phometheusMetricNameToGraphiteMetricName(metricValue: MetricValue): String = {
-    (getGlobalLabelValuesOrDefault(metricValue.clusterName) ++ metricValue.labels
-      ).map( x => x.replaceAll("\\.", "_")).mkString(".") + "." + metricValue.definition.name;
-  }
-
   override def report(m: MetricValue): Unit = {
     if (metricWhitelist.exists(m.definition.name.matches)) {
       val metric = metrics.getOrElse(m.definition, throw new IllegalArgumentException(s"No metric with definition ${m.definition.name} registered"))
       metric.labels(getGlobalLabelValuesOrDefault(m.clusterName) ++ m.labels: _*).set(m.value)
-      graphiteConfig.foreach { conf =>
-        graphitePush(conf, phometheusMetricNameToGraphiteMetricName(m), m.value);
-      }
     }
   }
 
@@ -98,8 +65,4 @@ class PrometheusEndpointSink private(definitions: MetricDefinitions, metricWhite
   }
 
 
-  def getGlobalLabelValuesOrDefault(clusterName: ClusterName): List[String] = {
-    val globalLabelValuesForCluster = clusterGlobalLabels.getOrElse(clusterName, Map.empty)
-    globalLabelNames.map(l => globalLabelValuesForCluster.getOrElse(l, ""))
-  }
 }

--- a/src/test/scala/com/lightbend/kafkalagexporter/ConsumerGroupCollectorSpec.scala
+++ b/src/test/scala/com/lightbend/kafkalagexporter/ConsumerGroupCollectorSpec.scala
@@ -35,7 +35,7 @@ class ConsumerGroupCollectorSpec extends FreeSpec with Matchers with TestData wi
       topicPartitionTables = TopicPartitionTable(config.lookupTableSize, Map(topicPartition0 -> lookupTable))
     )
 
-    val behavior = ConsumerGroupCollector.collector(config, client, reporter.ref, state)
+    val behavior = ConsumerGroupCollector.collector(config, client, List(reporter.ref), state)
     val testKit = BehaviorTestKit(behavior)
 
     val newEarliestOffsets = PartitionOffsets(topicPartition0 -> Point(offset = 0, time = timestampNow))
@@ -102,7 +102,7 @@ class ConsumerGroupCollectorSpec extends FreeSpec with Matchers with TestData wi
       )),
     )
 
-    val behavior = ConsumerGroupCollector.collector(config, client, reporter.ref, state)
+    val behavior = ConsumerGroupCollector.collector(config, client, List(reporter.ref), state)
     val testKit = BehaviorTestKit(behavior)
 
     val newEarliestOffsets = PartitionOffsets(
@@ -149,7 +149,7 @@ class ConsumerGroupCollectorSpec extends FreeSpec with Matchers with TestData wi
       )),
     )
 
-    val behavior = ConsumerGroupCollector.collector(config, client, reporter.ref, state)
+    val behavior = ConsumerGroupCollector.collector(config, client, List(reporter.ref), state)
     val testKit = BehaviorTestKit(behavior)
 
     val newEarliestOffsets = PartitionOffsets(
@@ -195,7 +195,7 @@ class ConsumerGroupCollectorSpec extends FreeSpec with Matchers with TestData wi
       topicPartitionTables = TopicPartitionTable(config.lookupTableSize, Map(topicPartition0 -> lookupTable))
     )
 
-    val behavior = ConsumerGroupCollector.collector(config, client, reporter.ref, state)
+    val behavior = ConsumerGroupCollector.collector(config, client, List(reporter.ref), state)
     val testKit = BehaviorTestKit(behavior)
 
     val newEarliestOffsets = PartitionOffsets(topicPartition0 -> Point(offset = 0, time = timestampNow))
@@ -274,7 +274,7 @@ class ConsumerGroupCollectorSpec extends FreeSpec with Matchers with TestData wi
     }
 
     "remove metric for consumer ids no longer being reported" in {
-      val behavior = ConsumerGroupCollector.collector(config, client, reporter.ref, newState())
+      val behavior = ConsumerGroupCollector.collector(config, client, List(reporter.ref), newState())
       val testKit = BehaviorTestKit(behavior)
 
       val newConsumerId = s"$consumerId-new"
@@ -296,7 +296,7 @@ class ConsumerGroupCollectorSpec extends FreeSpec with Matchers with TestData wi
     }
 
     "remove metrics for topic group partitions no longer being reported" in {
-      val behavior = ConsumerGroupCollector.collector(config, client, reporter.ref, newState())
+      val behavior = ConsumerGroupCollector.collector(config, client, List(reporter.ref), newState())
       val testKit = BehaviorTestKit(behavior)
 
       val newGroupId = s"$groupId-new"
@@ -325,7 +325,7 @@ class ConsumerGroupCollectorSpec extends FreeSpec with Matchers with TestData wi
       // see example: https://gist.github.com/patriknw/5f0c54f5748d25d7928389165098b89e#file-synctestingfsmmockitoexamplespec
       val collectorBehavior = spy(new ConsumerGroupCollector.CollectorBehavior)
 
-      val behavior = collectorBehavior.collector(config, client, reporter.ref, newState())
+      val behavior = collectorBehavior.collector(config, client, List(reporter.ref), newState())
       val testKit = BehaviorTestKit(behavior)
 
       val snapshot = ConsumerGroupCollector.OffsetsSnapshot(
@@ -359,7 +359,7 @@ class ConsumerGroupCollectorSpec extends FreeSpec with Matchers with TestData wi
         verify(collectorBehavior, times(2)).collector(
           any[ConsumerGroupCollector.CollectorConfig],
           any[KafkaClient.KafkaClientContract],
-          any[ActorRef[MetricsSink.Message]],
+          any[List[ActorRef[MetricsSink.Message]]],
           argThat[ConsumerGroupCollector.CollectorState](_.topicPartitionTables.tables.isEmpty)
         )
       }

--- a/src/test/scala/com/lightbend/kafkalagexporter/GraphiteEndpointSinkTest.scala
+++ b/src/test/scala/com/lightbend/kafkalagexporter/GraphiteEndpointSinkTest.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2019 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package com.lightbend.kafkalagexporter
+
+import org.scalatest._
+
+class GraphiteEndpointSinkTest extends fixture.FreeSpec with Matchers {
+
+  class GraphiteServer extends Thread {
+    import java.net.ServerSocket
+    import java.io._
+    val server = new ServerSocket(0)
+    var line = ""
+    override def run() : Unit = {
+      val connection = server.accept
+      val input = new BufferedReader(new InputStreamReader(connection.getInputStream))
+      line = input.readLine()
+      server.close();
+    }
+  }
+
+  case class Fixture(server: GraphiteServer)
+  type FixtureParam = Fixture
+
+
+  override def withFixture(test: OneArgTest): Outcome = {
+    val server = new GraphiteServer()
+    server.start()
+    test(Fixture(server))
+  }
+
+  "GraphiteEndpointSinkImpl should" - {
+
+    "report only metrics which match the regex" in { fixture =>
+      val sink = GraphiteEndpointSink(List("kafka_consumergroup_group_max_lag"), Map("cluster" -> Map.empty),
+        Some(GraphiteConfig("localhost", fixture.server.server.getLocalPort(), None)))
+      sink.report(Metrics.GroupValueMessage(Metrics.MaxGroupOffsetLagMetric, "cluster", "group", 100))
+      sink.report(Metrics.GroupValueMessage(Metrics.MaxGroupTimeLagMetric, "cluster", "group", 1))
+      fixture.server.join()
+      fixture.server.line should startWith ("cluster.group.kafka_consumergroup_group_max_lag 100.0 ")
+    }
+
+  }
+
+}
+

--- a/src/test/scala/com/lightbend/kafkalagexporter/PrometheusEndpointSinkTest.scala
+++ b/src/test/scala/com/lightbend/kafkalagexporter/PrometheusEndpointSinkTest.scala
@@ -38,7 +38,7 @@ class PrometheusEndpointSinkTest extends fixture.FreeSpec with Matchers {
   "PrometheusEndpointSinkImpl should" - {
 
     "register only metrics which match the regex" in { fixture =>
-      PrometheusEndpointSink(Metrics.definitions, List(".*max_lag.*"), Map("cluster" -> Map.empty), fixture.server, fixture.registry)
+      PrometheusEndpointSink(Metrics.definitions, List(".*max_lag.*"), Map("cluster" -> Map.empty), fixture.server, fixture.registry, None)
       val metricSamples = fixture.registry.metricFamilySamples().asScala.toSet
 
       metricSamples.map(_.name).intersect(Metrics.definitions.map(_.name).toSet) should contain theSameElementsAs
@@ -58,7 +58,7 @@ class PrometheusEndpointSinkTest extends fixture.FreeSpec with Matchers {
         ),
         "cluster3" -> Map.empty[String, String]
       )
-      val sink = PrometheusEndpointSink(Metrics.definitions, List(".*"), groupLabel, fixture.server, fixture.registry)
+      val sink = PrometheusEndpointSink(Metrics.definitions, List(".*"), groupLabel, fixture.server, fixture.registry, None)
       sink.report(Metrics.GroupValueMessage(Metrics.MaxGroupTimeLagMetric, "cluster", "group", 1))
       sink.report(Metrics.GroupValueMessage(Metrics.MaxGroupTimeLagMetric, "cluster2", "group", 1))
       sink.report(Metrics.GroupValueMessage(Metrics.MaxGroupTimeLagMetric, "cluster3", "group", 1))
@@ -119,7 +119,7 @@ class PrometheusEndpointSinkTest extends fixture.FreeSpec with Matchers {
       val groupLabel = Map(
         "cluster" -> Map.empty[String, String]
       )
-      val sink = PrometheusEndpointSink(Metrics.definitions, List(".*"), groupLabel, fixture.server, fixture.registry)
+      val sink = PrometheusEndpointSink(Metrics.definitions, List(".*"), groupLabel, fixture.server, fixture.registry, None)
       sink.report(Metrics.GroupValueMessage(Metrics.MaxGroupTimeLagMetric, "cluster", "group", 1))
 
       val metricSamples = fixture.registry.metricFamilySamples().asScala.toList
@@ -145,7 +145,7 @@ class PrometheusEndpointSinkTest extends fixture.FreeSpec with Matchers {
 
     "report only metrics which match the regex" in { fixture =>
       val sink = PrometheusEndpointSink(Metrics.definitions, List("kafka_consumergroup_group_max_lag"), Map("cluster" -> Map.empty),
-        fixture.server, fixture.registry)
+        fixture.server, fixture.registry, None)
       sink.report(Metrics.GroupValueMessage(Metrics.MaxGroupOffsetLagMetric, "cluster", "group", 100))
       sink.report(Metrics.GroupValueMessage(Metrics.MaxGroupTimeLagMetric, "cluster", "group", 1))
       val labels = Array[String]("cluster_name", "group")
@@ -157,7 +157,7 @@ class PrometheusEndpointSinkTest extends fixture.FreeSpec with Matchers {
 
     "remove only metrics which match the regex" in { fixture =>
       val sink = PrometheusEndpointSink(Metrics.definitions, List("kafka_consumergroup_group_max_lag"), Map("cluster" -> Map.empty),
-        fixture.server, fixture.registry)
+        fixture.server, fixture.registry, None)
       sink.report(Metrics.GroupValueMessage(Metrics.MaxGroupOffsetLagMetric, "cluster", "group", 100))
       sink.remove(Metrics.GroupRemoveMetricMessage(Metrics.MaxGroupOffsetLagMetric, "cluster", "group"))
       sink.remove(Metrics.GroupRemoveMetricMessage(Metrics.MaxGroupTimeLagMetric, "cluster", "group"))
@@ -172,7 +172,7 @@ class PrometheusEndpointSinkTest extends fixture.FreeSpec with Matchers {
         "clusterB" -> Map("environment" -> "production"),
         "clusterC" -> Map.empty[String, String]
       )
-      val sink = PrometheusEndpointSink(Metrics.definitions, List(""), clustersGlobalValuesMap, fixture.server, fixture.registry).asInstanceOf[PrometheusEndpointSink]
+      val sink = PrometheusEndpointSink(Metrics.definitions, List(""), clustersGlobalValuesMap, fixture.server, fixture.registry, None).asInstanceOf[PrometheusEndpointSink]
       sink.globalLabelNames shouldEqual List("environment", "location")
       sink.getGlobalLabelValuesOrDefault("clusterA") shouldEqual List("integration", "ny")
       sink.getGlobalLabelValuesOrDefault("clusterB") shouldEqual List("production", "")
@@ -182,7 +182,7 @@ class PrometheusEndpointSinkTest extends fixture.FreeSpec with Matchers {
 
     "should add blank value for the cluster label for the cluster label is not specified for the cluster" in { fixture =>
       val clustersGlobalValuesMap = Map.empty[String, Map[String, String]]
-      val sink = PrometheusEndpointSink(Metrics.definitions, List(""), clustersGlobalValuesMap, fixture.server, fixture.registry).asInstanceOf[PrometheusEndpointSink]
+      val sink = PrometheusEndpointSink(Metrics.definitions, List(""), clustersGlobalValuesMap, fixture.server, fixture.registry, None).asInstanceOf[PrometheusEndpointSink]
       sink.globalLabelNames shouldEqual List.empty
       sink.getGlobalLabelValuesOrDefault("clusterA") shouldEqual List.empty
       sink.getGlobalLabelValuesOrDefault("clusterB") shouldEqual List.empty

--- a/src/test/scala/com/lightbend/kafkalagexporter/PrometheusEndpointSinkTest.scala
+++ b/src/test/scala/com/lightbend/kafkalagexporter/PrometheusEndpointSinkTest.scala
@@ -38,7 +38,7 @@ class PrometheusEndpointSinkTest extends fixture.FreeSpec with Matchers {
   "PrometheusEndpointSinkImpl should" - {
 
     "register only metrics which match the regex" in { fixture =>
-      PrometheusEndpointSink(Metrics.definitions, List(".*max_lag.*"), Map("cluster" -> Map.empty), fixture.server, fixture.registry, None)
+      PrometheusEndpointSink(Metrics.definitions, List(".*max_lag.*"), Map("cluster" -> Map.empty), fixture.server, fixture.registry)
       val metricSamples = fixture.registry.metricFamilySamples().asScala.toSet
 
       metricSamples.map(_.name).intersect(Metrics.definitions.map(_.name).toSet) should contain theSameElementsAs
@@ -58,7 +58,7 @@ class PrometheusEndpointSinkTest extends fixture.FreeSpec with Matchers {
         ),
         "cluster3" -> Map.empty[String, String]
       )
-      val sink = PrometheusEndpointSink(Metrics.definitions, List(".*"), groupLabel, fixture.server, fixture.registry, None)
+      val sink = PrometheusEndpointSink(Metrics.definitions, List(".*"), groupLabel, fixture.server, fixture.registry)
       sink.report(Metrics.GroupValueMessage(Metrics.MaxGroupTimeLagMetric, "cluster", "group", 1))
       sink.report(Metrics.GroupValueMessage(Metrics.MaxGroupTimeLagMetric, "cluster2", "group", 1))
       sink.report(Metrics.GroupValueMessage(Metrics.MaxGroupTimeLagMetric, "cluster3", "group", 1))
@@ -119,7 +119,7 @@ class PrometheusEndpointSinkTest extends fixture.FreeSpec with Matchers {
       val groupLabel = Map(
         "cluster" -> Map.empty[String, String]
       )
-      val sink = PrometheusEndpointSink(Metrics.definitions, List(".*"), groupLabel, fixture.server, fixture.registry, None)
+      val sink = PrometheusEndpointSink(Metrics.definitions, List(".*"), groupLabel, fixture.server, fixture.registry)
       sink.report(Metrics.GroupValueMessage(Metrics.MaxGroupTimeLagMetric, "cluster", "group", 1))
 
       val metricSamples = fixture.registry.metricFamilySamples().asScala.toList
@@ -145,7 +145,7 @@ class PrometheusEndpointSinkTest extends fixture.FreeSpec with Matchers {
 
     "report only metrics which match the regex" in { fixture =>
       val sink = PrometheusEndpointSink(Metrics.definitions, List("kafka_consumergroup_group_max_lag"), Map("cluster" -> Map.empty),
-        fixture.server, fixture.registry, None)
+        fixture.server, fixture.registry)
       sink.report(Metrics.GroupValueMessage(Metrics.MaxGroupOffsetLagMetric, "cluster", "group", 100))
       sink.report(Metrics.GroupValueMessage(Metrics.MaxGroupTimeLagMetric, "cluster", "group", 1))
       val labels = Array[String]("cluster_name", "group")
@@ -157,7 +157,7 @@ class PrometheusEndpointSinkTest extends fixture.FreeSpec with Matchers {
 
     "remove only metrics which match the regex" in { fixture =>
       val sink = PrometheusEndpointSink(Metrics.definitions, List("kafka_consumergroup_group_max_lag"), Map("cluster" -> Map.empty),
-        fixture.server, fixture.registry, None)
+        fixture.server, fixture.registry)
       sink.report(Metrics.GroupValueMessage(Metrics.MaxGroupOffsetLagMetric, "cluster", "group", 100))
       sink.remove(Metrics.GroupRemoveMetricMessage(Metrics.MaxGroupOffsetLagMetric, "cluster", "group"))
       sink.remove(Metrics.GroupRemoveMetricMessage(Metrics.MaxGroupTimeLagMetric, "cluster", "group"))
@@ -172,7 +172,7 @@ class PrometheusEndpointSinkTest extends fixture.FreeSpec with Matchers {
         "clusterB" -> Map("environment" -> "production"),
         "clusterC" -> Map.empty[String, String]
       )
-      val sink = PrometheusEndpointSink(Metrics.definitions, List(""), clustersGlobalValuesMap, fixture.server, fixture.registry, None).asInstanceOf[PrometheusEndpointSink]
+      val sink = PrometheusEndpointSink(Metrics.definitions, List(""), clustersGlobalValuesMap, fixture.server, fixture.registry).asInstanceOf[PrometheusEndpointSink]
       sink.globalLabelNames shouldEqual List("environment", "location")
       sink.getGlobalLabelValuesOrDefault("clusterA") shouldEqual List("integration", "ny")
       sink.getGlobalLabelValuesOrDefault("clusterB") shouldEqual List("production", "")
@@ -182,7 +182,7 @@ class PrometheusEndpointSinkTest extends fixture.FreeSpec with Matchers {
 
     "should add blank value for the cluster label for the cluster label is not specified for the cluster" in { fixture =>
       val clustersGlobalValuesMap = Map.empty[String, Map[String, String]]
-      val sink = PrometheusEndpointSink(Metrics.definitions, List(""), clustersGlobalValuesMap, fixture.server, fixture.registry, None).asInstanceOf[PrometheusEndpointSink]
+      val sink = PrometheusEndpointSink(Metrics.definitions, List(""), clustersGlobalValuesMap, fixture.server, fixture.registry).asInstanceOf[PrometheusEndpointSink]
       sink.globalLabelNames shouldEqual List.empty
       sink.getGlobalLabelValuesOrDefault("clusterA") shouldEqual List.empty
       sink.getGlobalLabelValuesOrDefault("clusterB") shouldEqual List.empty


### PR DESCRIPTION
This allows to specify a graphite output via the following config:

```
  graphite-host = "localhost"
  graphite-port = 2003
```
This translates prometheus labels into a graphite metric path.