### PR TITLE
Support consumer groups for which member information is unavailable.

### DIFF
--- a/src/main/scala/com/lightbend/kafkalagexporter/KafkaClient.scala
+++ b/src/main/scala/com/lightbend/kafkalagexporter/KafkaClient.scala
@@ -161,8 +161,6 @@ class KafkaClient private[kafkalagexporter](cluster: KafkaCluster,
 
   /**
     * Retrieve partitions by consumer group ID. This is used in case when members info is unavailable for the group.
-    * @param groupId
-    * @return
     */
   def getGroupPartitionsInfo(groupId: String): Future[List[Domain.GroupTopicPartition]] = {
     for {

--- a/src/main/scala/com/lightbend/kafkalagexporter/KafkaClient.scala
+++ b/src/main/scala/com/lightbend/kafkalagexporter/KafkaClient.scala
@@ -58,7 +58,7 @@ object KafkaClient {
   private def createAdminClient(cluster: KafkaCluster, clientTimeout: FiniteDuration): AdminClient = {
     val props = new Properties()
     // AdminClient config: https://kafka.apache.org/documentation/#adminclientconfigs
-    props.putAll(cluster.adminClientProperties.asJava)
+    cluster.adminClientProperties foreach { case (k, v) => props.setProperty(k, v)}
     props.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, cluster.bootstrapBrokers)
     props.put(AdminClientConfig.REQUEST_TIMEOUT_MS_CONFIG, clientTimeout.toMillis.toString)
     props.put(AdminClientConfig.RETRIES_CONFIG, AdminClientConfigRetries.toString)
@@ -70,7 +70,7 @@ object KafkaClient {
     val props = new Properties()
     val deserializer = (new ByteArrayDeserializer).getClass.getName
     // KafkaConsumer config: https://kafka.apache.org/documentation/#consumerconfigs
-    props.putAll(cluster.consumerProperties.asJava)
+    cluster.consumerProperties foreach { case (k, v) => props.setProperty(k, v)}
     props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, cluster.bootstrapBrokers)
     props.put(ConsumerConfig.GROUP_ID_CONFIG, groupId)
     props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, ConsumerConfigAutoCommit.toString)
@@ -150,10 +150,32 @@ class KafkaClient private[kafkalagexporter](cluster: KafkaCluster,
       groups <- adminClient.listConsumerGroups()
       groupIds = getGroupIds(groups)
       groupDescriptions <- adminClient.describeConsumerGroups(groupIds)
+      noMemberGroups = groupDescriptions.asScala.filter{ case (_, d) => d.members().isEmpty}.keys
+      noMemberGroupsPartitionsInfo <- Future.sequence(noMemberGroups.map(g => getGroupPartitionsInfo(g)))
     } yield {
       val gtps = groupDescriptions.asScala.flatMap { case (id, desc) => groupTopicPartitions(id, desc) }.toList
-      (groupIds, gtps)
+      val gtpsNoMembers = noMemberGroupsPartitionsInfo.flatten
+      (groupIds, gtps ++ gtpsNoMembers)
     }
+  }
+
+  /**
+    * Retrieve partitions by consumer group ID. This is used in case when members info is unavailable for the group.
+    * @param groupId
+    * @return
+    */
+  def getGroupPartitionsInfo(groupId: String): Future[List[Domain.GroupTopicPartition]] = {
+    for {
+      offsetsMap <- adminClient.listConsumerGroupOffsets(groupId)
+      topicPartitions = offsetsMap.keySet.asScala.toList
+    } yield topicPartitions.map(ktp => Domain.GroupTopicPartition(
+      groupId,
+      "unknown",
+      "unknown",
+      "unknown",
+      ktp.topic(),
+      ktp.partition()
+    ))
   }
 
   private[kafkalagexporter] def getGroupIds(groups: util.Collection[ConsumerGroupListing]): List[String] =


### PR DESCRIPTION
This is a fix for the issue https://github.com/lightbend/kafka-lag-exporter/issues/126 .
It allows to report lag for the consumer groups that don't have members information. 
Such situation is actually happening for the consumers running under Flink.

Also minor fix in setting properties, KafkaClient.scala lines 61 and 73:
the documentation for java.util.Properties suggests not to use putAll method because it is not type-safe (in fact, in my environment those two lines did not compile). They suggest using setProperty method.

I tested this fix in my local environment.