### PR TITLE
Support init containers in helm chart

### DIFF
--- a/charts/kafka-lag-exporter/templates/000-ServiceAccount.yaml
+++ b/charts/kafka-lag-exporter/templates/000-ServiceAccount.yaml
@@ -2,7 +2,11 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  {{- if .Values.serviceAccount.nameOverride }}
+  name: {{ .Values.serviceAccount.nameOverride }}
+  {{- else }}
   name: {{ include "kafka-lag-exporter.fullname" . }}-serviceaccount
+  {{- end }}
   labels:
     app.kubernetes.io/name: {{ include "kafka-lag-exporter.name" . }}
     helm.sh/chart: {{ include "kafka-lag-exporter.chart" . }}

--- a/charts/kafka-lag-exporter/templates/040-Deployment.yaml
+++ b/charts/kafka-lag-exporter/templates/040-Deployment.yaml
@@ -24,7 +24,11 @@ spec:
       {{- end }}
     spec:
       {{- if or .Values.watchers.strimzi .Values.serviceAccount.create }}
+      {{- if .Values.serviceAccount.nameOverride }}
+      serviceAccountName: {{ .Values.serviceAccount.nameOverride }}
+      {{- else }}
       serviceAccountName: {{ include "kafka-lag-exporter.fullname" . }}-serviceaccount
+      {{- end }}
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}

--- a/charts/kafka-lag-exporter/templates/040-Deployment.yaml
+++ b/charts/kafka-lag-exporter/templates/040-Deployment.yaml
@@ -38,7 +38,10 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          env: []
+          {{- if .Values.env }}
+          env:
+{{ toYaml .Values.env | indent 10 }}
+          {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.service.port }}

--- a/charts/kafka-lag-exporter/templates/040-Deployment.yaml
+++ b/charts/kafka-lag-exporter/templates/040-Deployment.yaml
@@ -62,6 +62,9 @@ spec:
           {{- end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
+    {{- with .Values.initContainers }}
+      initContainers: {{ toYaml . | nindent 8 }}
+    {{- end }}
     {{- with .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}

--- a/charts/kafka-lag-exporter/templates/040-Deployment.yaml
+++ b/charts/kafka-lag-exporter/templates/040-Deployment.yaml
@@ -64,6 +64,10 @@ spec:
               subPath: {{ .subPath }}
               readOnly: {{ .readOnly }}
           {{- end }}
+          {{- range .Values.extraMounts }}
+            - name: {{ .name }}
+              mountPath: {{ .mountPath }}
+          {{- end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
     {{- with .Values.initContainers }}
@@ -89,4 +93,8 @@ spec:
         - name: {{ .name }}
           configMap:
             name: {{ .configMap }}
+      {{- end }}
+      {{- range .Values.extraMounts }}
+        - name: {{ .name }}
+{{ toYaml .mount | indent 10 }}
       {{- end }}

--- a/charts/kafka-lag-exporter/values.yaml
+++ b/charts/kafka-lag-exporter/values.yaml
@@ -113,6 +113,9 @@ extraMounts: []
   #     emptyDir:
   #       medium: Memory
   #   mountPath: /var/run/my-secrets
+env: {}
+  # - name: JAVA_OPTS
+  #   value: "-Djava.security.auth.login.config=/var/run/my-secrets/jaasConfig"
 podAnnotations: {}
   # foo: bar
 

--- a/charts/kafka-lag-exporter/values.yaml
+++ b/charts/kafka-lag-exporter/values.yaml
@@ -43,6 +43,9 @@ watchers:
 ## Otherwise, the default service account for the namespace will be used.
 serviceAccount:
   create: false
+  ## The name of the service account will be generated based on the release name, use nameOverride to override
+  ## with a static name.
+  # nameOverride: my-serviceaccount
 
 ## You can use regex to control the metrics exposed by Prometheus endpoint.
 ## Any metric that matches one of the regex in the whitelist will be exposed.

--- a/charts/kafka-lag-exporter/values.yaml
+++ b/charts/kafka-lag-exporter/values.yaml
@@ -107,6 +107,12 @@ extraConfigmapMounts: []
   #   mountPath: /etc/pki/ca-trust/extracted/java/cacerts
   #   subPath: ca-bundle.jks
   #   readOnly: true
+extraMounts: []
+  # - name: my-secrets
+  #   mount:
+  #     emptyDir:
+  #       medium: Memory
+  #   mountPath: /var/run/my-secrets
 podAnnotations: {}
   # foo: bar
 

--- a/charts/kafka-lag-exporter/values.yaml
+++ b/charts/kafka-lag-exporter/values.yaml
@@ -80,6 +80,11 @@ securityContext: {}
   # runAsNonRoot: true
   # capabilities:
   #   drop: ["all"]
+initContainers: []
+## Init containers to be added to the pod.
+# - name: my-init-container
+#   image: busybox:latest
+#   command: ['sh', '-c', 'echo hello']
 service:
   type: ClusterIP
   port: 8000


### PR DESCRIPTION
This PR add support for configuring init containers for the pod. The usecase for these can be many, but e.g. for adding secrets from an external source. In addition to support for adding the init container specs, the PR adds support for:

- Specifying the serviceaccount name
- Add extra mounts
- Add environment variables

