### PR TITLE
Configurable readiness and liveness probes in helm chart

### DIFF
--- a/charts/kafka-lag-exporter/templates/040-Deployment.yaml
+++ b/charts/kafka-lag-exporter/templates/040-Deployment.yaml
@@ -54,10 +54,20 @@ spec:
             httpGet:
               path: /
               port: http
+            initialDelaySeconds: {{ .Values.livenessProbeInitialDelay }}
+            periodSeconds: {{ .Values.livenessProbePeriodSeconds }}
+            timeoutSeconds: {{ .Values.livenessProbeTimeout }}
+            failureThreshold: {{ .Values.livenessProbeFailureThreshold }}
+            successThreshold: {{ .Values.livenessProbeSuccessThreshold }}
           readinessProbe:
             httpGet:
               path: /
               port: http
+            initialDelaySeconds: {{ .Values.readinessProbeInitialDelay }}
+            periodSeconds: {{ .Values.readinessProbePeriodSeconds }}
+            timeoutSeconds: {{ .Values.readinessProbeTimeout }}
+            failureThreshold: {{ .Values.readinessProbeFailureThreshold }}
+            successThreshold: {{ .Values.readinessProbeSuccessThreshold }}
           volumeMounts:
             - name: config-volume
               mountPath: /opt/docker/conf/

--- a/charts/kafka-lag-exporter/values.yaml
+++ b/charts/kafka-lag-exporter/values.yaml
@@ -118,6 +118,18 @@ env: {}
   #   value: "-Djava.security.auth.login.config=/var/run/my-secrets/jaasConfig"
 podAnnotations: {}
   # foo: bar
+## Readiness and liveness probe initial delay and timeout
+## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
+readinessProbeInitialDelay: 30
+readinessProbePeriodSeconds: 5
+readinessProbeTimeout: 30
+readinessProbeFailureThreshold: 3
+readinessProbeSuccessThreshold: 1
+livenessProbeInitialDelay: 30
+livenessProbePeriodSeconds: 15
+livenessProbeTimeout: 30
+livenessProbeFailureThreshold: 3
+livenessProbeSuccessThreshold: 1
 
 prometheus:
   serviceMonitor:


### PR DESCRIPTION
fixes #144 Add variables to configure the liveness and readiness probes delay and timeouts in the helm chart