### PR TITLE
Swap embedded-kafka for testcontainers

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -37,7 +37,7 @@ lazy val kafkaLagExporter =
         MockitoScala,
         AkkaStreamsTestKit,
         AlpakkaKafkaTestKit,
-        EmbeddedKafka,
+        Testcontainers,
         AkkaHttp
       ),
       dockerRepository := Option(System.getenv("DOCKER_REPOSITORY")).orElse(None),
@@ -62,6 +62,7 @@ lazy val kafkaLagExporter =
         s"./scripts/update_chart.sh ${version.value} $repo" !
       },
       skip in publish := true,
+      parallelExecution in Test := false,
       releaseProcess := Seq[ReleaseStep](
         lintHelmChart,                          // Lint the Helm Chart for errors
         checkSnapshotDependencies,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object Version {
   val Scala      = "2.12.11"
-  val Akka       = "2.6.4"
+  val Akka       = "2.6.8"
   val Prometheus = "0.8.1"
   val Fabric8    = "4.9.1"
   val Kafka      = "2.5.0"
@@ -37,11 +37,12 @@ object Dependencies {
   val Fabric8Client         = "io.fabric8"              %  "kubernetes-client"         % Version.Fabric8
   val ScalaJava8Compat      = "org.scala-lang.modules"  %% "scala-java8-compat"        % "0.9.0"
 
+  /* Test */
   val ScalaTest             = "org.scalatest"           %% "scalatest"                 % "3.0.5"             % Test
   val AkkaTypedTestKit      = "com.typesafe.akka"       %% "akka-actor-testkit-typed"  % Version.Akka        % Test
   val AkkaStreamsTestKit    = "com.typesafe.akka"       %% "akka-stream-testkit"       % Version.Akka        % Test
   val MockitoScala          = "org.mockito"             %% "mockito-scala"             % "1.0.8"             % Test
-  val AlpakkaKafkaTestKit   = "com.typesafe.akka"       %% "akka-stream-kafka-testkit" % "2.0.1"             % Test excludeAll(jacksonExclusionRule, log4jExclusionRule, slf4jExclusionRule)
-  val EmbeddedKafka         = "io.github.embeddedkafka" %% "embedded-kafka"            % Version.EmbeddedKafka % Test excludeAll(jacksonExclusionRule, log4jExclusionRule, slf4jExclusionRule)
+  val AlpakkaKafkaTestKit   = "com.typesafe.akka"       %% "akka-stream-kafka-testkit" % "2.0.4"             % Test excludeAll(jacksonExclusionRule, log4jExclusionRule, slf4jExclusionRule)
+  val Testcontainers        = "org.testcontainers"      %  "kafka"                     % "1.14.3"            % Test
   val AkkaHttp              = "com.typesafe.akka"       %% "akka-http"                 % "10.1.11"           % Test
 }

--- a/src/test/scala/com/lightbend/kafkalagexporter/integration/LagSim.scala
+++ b/src/test/scala/com/lightbend/kafkalagexporter/integration/LagSim.scala
@@ -7,9 +7,9 @@ package com.lightbend.kafkalagexporter.integration
 import akka.actor.Cancellable
 import akka.actor.typed.scaladsl.Behaviors
 import akka.actor.typed.{Behavior, PostStop}
-import akka.kafka.{CommitterSettings, Subscriptions}
-import akka.kafka.scaladsl.{Committer, Consumer}
+import akka.kafka.scaladsl.Consumer
 import akka.kafka.testkit.scaladsl.KafkaSpec
+import akka.kafka.{CommitterSettings, Subscriptions}
 import akka.stream.OverflowStrategy
 import akka.stream.scaladsl.Keep
 import akka.stream.testkit.scaladsl.TestSink

--- a/src/test/scala/com/lightbend/kafkalagexporter/integration/MetricsEvictionSpec.scala
+++ b/src/test/scala/com/lightbend/kafkalagexporter/integration/MetricsEvictionSpec.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2019 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package com.lightbend.kafkalagexporter.integration
+
+import scala.jdk.CollectionConverters._
+import com.lightbend.kafkalagexporter.Metrics.{LastGroupOffsetMetric, LatestOffsetMetric, MaxGroupOffsetLagMetric, MaxGroupTimeLagMetric, OffsetLagMetric, TimeLagMetric}
+
+class MetricsEvictionSpec extends SpecBase(exporterPort = 8001) {
+
+  "kafka lag exporter" should {
+    "not report metrics for group members or partitions that no longer exist" in {
+      val group = createGroupId(1)
+      val partition = "0"
+      val topic = createTopic(1, 1, 1)
+
+      val offsetsToCommit = 5
+      val totalOffsets = 10
+
+      val rules = List(
+        Rule.create(LatestOffsetMetric, (actual: String) => actual shouldBe (totalOffsets + 1).toDouble.toString, clusterName, topic, partition),
+        Rule.create(LastGroupOffsetMetric, (actual: String) => actual shouldBe offsetsToCommit.toDouble.toString, clusterName, group, topic, partition),
+        Rule.create(OffsetLagMetric, (actual: String) => actual shouldBe (offsetsToCommit + 1).toDouble.toString, clusterName, group, topic, partition),
+        Rule.create(TimeLagMetric, (_: String) => (), clusterName, group, topic, partition),
+        Rule.create(MaxGroupOffsetLagMetric, (actual: String) => actual shouldBe (offsetsToCommit + 1).toDouble.toString, clusterName, group),
+        Rule.create(MaxGroupTimeLagMetric, (_: String) => (), clusterName, group)
+      )
+
+      val simulator = new LagSimulator(topic, group)
+      simulator.produceElements(totalOffsets)
+      simulator.consumeElements(offsetsToCommit)
+      simulator.shutdown()
+
+      eventually(scrapeAndAssert(exporterPort, "Assert offset-based metrics", rules: _*))
+
+      adminClient.deleteConsumerGroups(List(group).asJava)
+
+      eventually(scrapeAndAssertDne(exporterPort, "Assert offset-based metrics no longer exist", rules: _*))
+    }
+  }
+}


### PR DESCRIPTION
embedded-kafka is faster, but pollutes the classpath with kafka server deps when they're not needed.  embedded-kafka releases also lag Kafka, so sometimes different versions are required, which can cause conflicts on classpath as well.

Using testcontainers (Java managed Docker containers) eliminates this issue and makes it easy to test against older versions of Kafka.