### PR TITLE
Community and support disclaimer

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,7 @@ application written in [Scala](https://www.scala-lang.org/).
 For more information about Kafka Lag Exporter's features see Lightbend's blog post:
 [Monitor Kafka Consumer Group Latency with Kafka Lag Exporter](https://www.lightbend.com/blog/monitor-kafka-consumer-group-latency-with-kafka-lag-exporter).
 
-**Project Status:** *beta*
-
-**Author:** [Sean Glover](https://seanglover.com) ([@seg1o](https://twitter.com/seg1o))
+_Kafka Lag Exporter is maintained by [@seglo](https://github.com/seglo) and a community of contributors. It is not covered by support under the [Lightbend subscription](https://www.lightbend.com/subscription)._
 
 ## Metrics
 


### PR DESCRIPTION
Since this project has been used by a number of companies and individuals in the wild I think it's fair to say it's no longer in a _beta_ state. I replaced the project status wording with a general disclaimer about it being a community project, not supported (under a commercial subscription) from Lightbend.

Fixes #141