### PR TITLE
Evict all metrics for a cluster on collector stop or failure

### DIFF
--- a/src/test/scala/com/lightbend/kafkalagexporter/integration/ExporterPorts.scala
+++ b/src/test/scala/com/lightbend/kafkalagexporter/integration/ExporterPorts.scala
@@ -1,0 +1,7 @@
+package com.lightbend.kafkalagexporter.integration
+
+object ExporterPorts {
+  val IntegrationSpec = 8000
+  val MetricsEvictionSpec = 8001
+  val MetricsEvictionOnFailureSpec = 8002
+}

--- a/src/test/scala/com/lightbend/kafkalagexporter/integration/IntegrationSpec.scala
+++ b/src/test/scala/com/lightbend/kafkalagexporter/integration/IntegrationSpec.scala
@@ -10,7 +10,7 @@ import com.lightbend.kafkalagexporter.Metrics._
 
 import scala.util.Try
 
-class IntegrationSpec extends SpecBase(exporterPort = 8000) {
+class IntegrationSpec extends SpecBase(exporterPort = ExporterPorts.IntegrationSpec) {
 
   "kafka lag exporter" should {
     val group = createGroupId(1)

--- a/src/test/scala/com/lightbend/kafkalagexporter/integration/IntegrationSpec.scala
+++ b/src/test/scala/com/lightbend/kafkalagexporter/integration/IntegrationSpec.scala
@@ -25,6 +25,7 @@ class IntegrationSpec extends SpecBase(exporterPort = 8000) {
 
         val rules = List(
           Rule.create(LatestOffsetMetric, (actual: String) => actual shouldBe (totalOffsets + 1).toDouble.toString, clusterName, topic, partition),
+          Rule.create(EarliestOffsetMetric, (actual: String) => actual shouldBe 0.toDouble.toString, clusterName, topic, partition),
           Rule.create(LastGroupOffsetMetric, (actual: String) => actual shouldBe offsetsToCommit.toDouble.toString, clusterName, group, topic, partition),
           Rule.create(OffsetLagMetric, (actual: String) => actual shouldBe (offsetsToCommit + 1).toDouble.toString, clusterName, group, topic, partition),
           // TODO: update test so we can assert actual lag in time.  keep producer running for more than two polling cycles.

--- a/src/test/scala/com/lightbend/kafkalagexporter/integration/MetricsEvictionOnFailureSpec.scala
+++ b/src/test/scala/com/lightbend/kafkalagexporter/integration/MetricsEvictionOnFailureSpec.scala
@@ -6,7 +6,7 @@ package com.lightbend.kafkalagexporter.integration
 
 import com.lightbend.kafkalagexporter.Metrics._
 
-class MetricsEvictionOnFailureSpec extends SpecBase(exporterPort = 8001) {
+class MetricsEvictionOnFailureSpec extends SpecBase(exporterPort = ExporterPorts.MetricsEvictionOnFailureSpec) {
   "kafka lag exporter" should {
     "not report metrics for group members or partitions after a failure" in {
       val group = createGroupId(1)

--- a/src/test/scala/com/lightbend/kafkalagexporter/integration/MetricsEvictionOnFailureSpec.scala
+++ b/src/test/scala/com/lightbend/kafkalagexporter/integration/MetricsEvictionOnFailureSpec.scala
@@ -6,11 +6,9 @@ package com.lightbend.kafkalagexporter.integration
 
 import com.lightbend.kafkalagexporter.Metrics._
 
-import scala.jdk.CollectionConverters._
-
-class MetricsEvictionSpec extends SpecBase(exporterPort = 8001) {
+class MetricsEvictionOnFailureSpec extends SpecBase(exporterPort = 8001) {
   "kafka lag exporter" should {
-    "not report metrics for group members or partitions that no longer exist" in {
+    "not report metrics for group members or partitions after a failure" in {
       val group = createGroupId(1)
       val partition = "0"
       val topic = createTopic(1, 1, 1)
@@ -35,7 +33,7 @@ class MetricsEvictionSpec extends SpecBase(exporterPort = 8001) {
 
       eventually(scrapeAndAssert(exporterPort, "Assert offset-based metrics", rules: _*))
 
-      adminClient.deleteConsumerGroups(List(group).asJava)
+      stopKafka()
 
       eventually(scrapeAndAssertDne(exporterPort, "Assert offset-based metrics no longer exist", rules: _*))
     }

--- a/src/test/scala/com/lightbend/kafkalagexporter/integration/MetricsEvictionSpec.scala
+++ b/src/test/scala/com/lightbend/kafkalagexporter/integration/MetricsEvictionSpec.scala
@@ -8,7 +8,7 @@ import com.lightbend.kafkalagexporter.Metrics._
 
 import scala.jdk.CollectionConverters._
 
-class MetricsEvictionSpec extends SpecBase(exporterPort = 8001) {
+class MetricsEvictionSpec extends SpecBase(exporterPort = ExporterPorts.MetricsEvictionSpec) {
   "kafka lag exporter" should {
     "not report metrics for group members or partitions that no longer exist" in {
       val group = createGroupId(1)

--- a/src/test/scala/com/lightbend/kafkalagexporter/integration/SpecBase.scala
+++ b/src/test/scala/com/lightbend/kafkalagexporter/integration/SpecBase.scala
@@ -56,6 +56,6 @@ abstract class SpecBase(val exporterPort: Int)
 
   override def afterEach(): Unit = {
     kafkaLagExporter ! KafkaClusterManager.Stop
-    Await.result(kafkaLagExporter.whenTerminated, 10 seconds)
+    Await.result(kafkaLagExporter.whenTerminated, 15 seconds)
   }
 }


### PR DESCRIPTION
Fixes #110

Since metric reporters can outlive collector instances, stale metrics from a failed or removed cluster (i.e. a Strimzi cluster that was deleted) will remain listed indefinitely on the prometheus endpoint.  This PR evicts all metrics that are part of the collector's offset snapshot data when the collector shuts down gracefully or due to a failure.