### PR TITLE
Ability to extend and configure desired sink to report lag metrics, adding support to push lag metrics into InfluxDB as well

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,8 +229,9 @@ defaults defined in the project itself.  See [`reference.conf`](./src/main/resou
 
 ### Reporters
 
-It is possible to report (either or both):
+It is possible to report (either one, multiple or all):
 
+  - to influxdb via the config `kafka-lag-exporter.reporters.influxDB`
   - to graphite via the config `kafka-lag-exporter.reporters.graphite`
   - as prometheus via the config `kafka-lag-exporter.reporters.prometheus`
 
@@ -240,19 +241,25 @@ See section below for more information.
 
 General Configuration (`kafka-lag-exporter{}`)
 
-| Key                         | Default            | Description                                                                                                                           |
-|-----------------------------|--------------------|---------------------------------------------------------------------------------------------------------------------------------------|
-| `reporters.prometheus.port` | `8000`             | The port to run the Prometheus endpoint on                                                                                            |
-| `reporters.graphite.host`   | None               | The graphite host to send metrics to (if not set, will not output to graphite)                                                        |
-| `reporters.graphite.port`   | None               | The graphite port to send metrics to (if not set, will not output to graphite)                                                        |
-| `reporters.graphite.prefix` | None               | The graphite metric prefix (if not set, prefix will be empty)                                                                         |
-| `poll-interval`             | `30 seconds`       | How often to poll Kafka for latest and group offsets                                                                                  |
-| `lookup-table-size`         | `60`               | The maximum window size of the look up table **per partition**                                                                        |
-| `client-group-id`           | `kafkalagexporter` | Consumer group id of kafka-lag-exporter's client connections                                                                          |
-| `kafka-client-timeout`      | `10 seconds`       | Connection timeout when making API calls to Kafka                                                                                     |
-| `clusters`                  | `[]`               | A statically defined list of Kafka connection details.  This list is optional if you choose to use the Strimzi auto-discovery feature |
-| `watchers`                  | `{}`               | Settings for Kafka cluster "watchers" used for auto-discovery.                                                                        |
-| `metric-whitelist`          | `[".*"]`           | Regex of metrics to be exposed via Prometheus endpoint. Eg. `[".*_max_lag.*", "kafka_partition_latest_offset"]`                       |
+| Key                           | Default              | Description                                                                                                                           |
+|-------------------------------|----------------------|---------------------------------------------------------------------------------------------------------------------------------------|
+| `reporters.prometheus.port`   | `8000`               | The port to run the Prometheus endpoint on                                                                                            |
+| `reporters.graphite.host`     | None                 | The graphite host to send metrics to (if not set, will not output to graphite)                                                        |
+| `reporters.graphite.port`     | None                 | The graphite port to send metrics to (if not set, will not output to graphite)                                                        |
+| `reporters.graphite.prefix`   | None                 | The graphite metric prefix (if not set, prefix will be empty)                                                                         |
+| `reporters.influxDB.endpoint` | None                 | The influxDB host to send metrics to (if not set, will not output to influxDB)                                                        |
+| `reporters.influxDB.port`     | None                 | The influxDB port to send metrics to (if not set, will not output to influxDB)                                                        |
+| `reporters.influxDB.database` | `kafka_lag_exporter` | The influxDB database to send metrics to                                                                                              |
+| `reporters.influxDB.username` | None                 | The influxDB username to connect (if not set, username will be empty)                                                                 |
+| `reporters.influxDB.password` | None                 | The influxDB password to connect (if not set, password will be empty)                                                                 |
+| `reporters.influxDB.async`    | `true`               | Flag to enable influxDB async **non-blocking** write mode to send metrics                                                             |
+| `poll-interval`               | `30 seconds`         | How often to poll Kafka for latest and group offsets                                                                                  |
+| `lookup-table-size`           | `60`                 | The maximum window size of the look up table **per partition**                                                                        |
+| `client-group-id`             | `kafkalagexporter`   | Consumer group id of kafka-lag-exporter's client connections                                                                          |
+| `kafka-client-timeout`        | `10 seconds`         | Connection timeout when making API calls to Kafka                                                                                     |
+| `clusters`                    | `[]`                 | A statically defined list of Kafka connection details.  This list is optional if you choose to use the Strimzi auto-discovery feature |
+| `watchers`                    | `{}`                 | Settings for Kafka cluster "watchers" used for auto-discovery.                                                                        |
+| `metric-whitelist`            | `[".*"]`             | Regex of metrics to be exposed via Prometheus endpoint. Eg. `[".*_max_lag.*", "kafka_partition_latest_offset"]`                       |
 
 Kafka Cluster Connection Details (`kafka-lag-exporter.clusters[]`)
 

--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ defaults defined in the project itself.  See [`reference.conf`](./src/main/resou
 
 It is possible to report (either one, multiple or all):
 
-  - to influxdb via the config `kafka-lag-exporter.reporters.influxDB`
+  - to influxdb via the config `kafka-lag-exporter.reporters.influxdb`
   - to graphite via the config `kafka-lag-exporter.reporters.graphite`
   - as prometheus via the config `kafka-lag-exporter.reporters.prometheus`
 
@@ -247,12 +247,12 @@ General Configuration (`kafka-lag-exporter{}`)
 | `reporters.graphite.host`     | None                 | The graphite host to send metrics to (if not set, will not output to graphite)                                                        |
 | `reporters.graphite.port`     | None                 | The graphite port to send metrics to (if not set, will not output to graphite)                                                        |
 | `reporters.graphite.prefix`   | None                 | The graphite metric prefix (if not set, prefix will be empty)                                                                         |
-| `reporters.influxDB.endpoint` | None                 | The influxDB host to send metrics to (if not set, will not output to influxDB)                                                        |
-| `reporters.influxDB.port`     | None                 | The influxDB port to send metrics to (if not set, will not output to influxDB)                                                        |
-| `reporters.influxDB.database` | `kafka_lag_exporter` | The influxDB database to send metrics to                                                                                              |
-| `reporters.influxDB.username` | None                 | The influxDB username to connect (if not set, username will be empty)                                                                 |
-| `reporters.influxDB.password` | None                 | The influxDB password to connect (if not set, password will be empty)                                                                 |
-| `reporters.influxDB.async`    | `true`               | Flag to enable influxDB async **non-blocking** write mode to send metrics                                                             |
+| `reporters.influxdb.endpoint` | None                 | The influxdb host to send metrics to (if not set, will not output to influxdb)                                                        |
+| `reporters.influxdb.port`     | None                 | The influxdb port to send metrics to (if not set, will not output to influxdb)                                                        |
+| `reporters.influxdb.database` | `kafka_lag_exporter` | The influxdb database to send metrics to                                                                                              |
+| `reporters.influxdb.username` | None                 | The influxdb username to connect (if not set, username will be empty)                                                                 |
+| `reporters.influxdb.password` | None                 | The influxdb password to connect (if not set, password will be empty)                                                                 |
+| `reporters.influxdb.async`    | `true`               | Flag to enable influxdb async **non-blocking** write mode to send metrics                                                             |
 | `poll-interval`               | `30 seconds`         | How often to poll Kafka for latest and group offsets                                                                                  |
 | `lookup-table-size`           | `60`                 | The maximum window size of the look up table **per partition**                                                                        |
 | `client-group-id`             | `kafkalagexporter`   | Consumer group id of kafka-lag-exporter's client connections                                                                          |

--- a/build.sbt
+++ b/build.sbt
@@ -25,6 +25,7 @@ lazy val kafkaLagExporter =
         AkkaSlf4j,
         AkkaStreams,
         AkkaStreamsProtobuf,
+        AkkaInfluxDB,
         Fabric8Model,
         Fabric8Client,
         Prometheus,
@@ -38,6 +39,7 @@ lazy val kafkaLagExporter =
         AkkaStreamsTestKit,
         AlpakkaKafkaTestKit,
         Testcontainers,
+        EmbedInflux,
         AkkaHttp
       ),
       dockerRepository := Option(System.getenv("DOCKER_REPOSITORY")).orElse(None),

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -22,20 +22,21 @@ object Dependencies {
   private val log4jExclusionRule = ExclusionRule("log4j")
   private val slf4jExclusionRule = ExclusionRule("org.slf4j")
 
-  val LightbendConfig       = "com.typesafe"            %  "config"                    % "1.3.2"
-  val Kafka                 = "org.apache.kafka"        %% "kafka"                     % Version.Kafka excludeAll (jacksonExclusionRule, log4jExclusionRule, slf4jExclusionRule)
-  val Akka                  = "com.typesafe.akka"       %% "akka-actor"                % Version.Akka
-  val AkkaTyped             = "com.typesafe.akka"       %% "akka-actor-typed"          % Version.Akka
-  val AkkaSlf4j             = "com.typesafe.akka"       %% "akka-slf4j"                % Version.Akka
-  val AkkaStreams           = "com.typesafe.akka"       %% "akka-stream"               % Version.Akka
-  val AkkaStreamsProtobuf   = "com.typesafe.akka"       %% "akka-protobuf"             % Version.Akka
-  val Logback               = "ch.qos.logback"          %  "logback-classic"           % "1.2.3"
-  val Prometheus            = "io.prometheus"           %  "simpleclient"              % Version.Prometheus
-  val PrometheusHotSpot     = "io.prometheus"           %  "simpleclient_hotspot"      % Version.Prometheus
-  val PrometheusHttpServer  = "io.prometheus"           %  "simpleclient_httpserver"   % Version.Prometheus
-  val Fabric8Model          = "io.fabric8"              %  "kubernetes-model"          % Version.Fabric8
-  val Fabric8Client         = "io.fabric8"              %  "kubernetes-client"         % Version.Fabric8
-  val ScalaJava8Compat      = "org.scala-lang.modules"  %% "scala-java8-compat"        % "0.9.0"
+  val LightbendConfig       = "com.typesafe"            %  "config"                       % "1.3.2"
+  val Kafka                 = "org.apache.kafka"        %% "kafka"                        % Version.Kafka excludeAll (jacksonExclusionRule, log4jExclusionRule, slf4jExclusionRule)
+  val Akka                  = "com.typesafe.akka"       %% "akka-actor"                   % Version.Akka
+  val AkkaTyped             = "com.typesafe.akka"       %% "akka-actor-typed"             % Version.Akka
+  val AkkaSlf4j             = "com.typesafe.akka"       %% "akka-slf4j"                   % Version.Akka
+  val AkkaStreams           = "com.typesafe.akka"       %% "akka-stream"                  % Version.Akka
+  val AkkaStreamsProtobuf   = "com.typesafe.akka"       %% "akka-protobuf"                % Version.Akka
+  val AkkaInfluxDB          = "com.lightbend.akka"      %% "akka-stream-alpakka-influxdb" % "1.1.2"
+  val Logback               = "ch.qos.logback"          %  "logback-classic"              % "1.2.3"
+  val Prometheus            = "io.prometheus"           %  "simpleclient"                 % Version.Prometheus
+  val PrometheusHotSpot     = "io.prometheus"           %  "simpleclient_hotspot"         % Version.Prometheus
+  val PrometheusHttpServer  = "io.prometheus"           %  "simpleclient_httpserver"      % Version.Prometheus
+  val Fabric8Model          = "io.fabric8"              %  "kubernetes-model"             % Version.Fabric8
+  val Fabric8Client         = "io.fabric8"              %  "kubernetes-client"            % Version.Fabric8
+  val ScalaJava8Compat      = "org.scala-lang.modules"  %% "scala-java8-compat"           % "0.9.0"
 
   /* Test */
   val ScalaTest             = "org.scalatest"           %% "scalatest"                 % "3.0.5"             % Test
@@ -44,5 +45,6 @@ object Dependencies {
   val MockitoScala          = "org.mockito"             %% "mockito-scala"             % "1.0.8"             % Test
   val AlpakkaKafkaTestKit   = "com.typesafe.akka"       %% "akka-stream-kafka-testkit" % "2.0.4"             % Test excludeAll(jacksonExclusionRule, log4jExclusionRule, slf4jExclusionRule)
   val Testcontainers        = "org.testcontainers"      %  "kafka"                     % "1.14.3"            % Test
-  val AkkaHttp              = "com.typesafe.akka"       %% "akka-http"                 % "10.1.11"           % Test
+  val AkkaHttp              = "com.typesafe.akka"       %% "akka-http"                 % "10.1.11"
+  val EmbedInflux           = "com.github.fsanaulla"    %% "scalatest-embedinflux"     % "0.2.3"             % Test
 }

--- a/src/main/scala/com/lightbend/kafkalagexporter/AppConfig.scala
+++ b/src/main/scala/com/lightbend/kafkalagexporter/AppConfig.scala
@@ -18,16 +18,25 @@ import scala.util.Try
 object AppConfig {
   def apply(config: Config): AppConfig = {
     val c = config.getConfig("kafka-lag-exporter")
-    val graphiteConfig: Option[GraphiteConfig] = (
-      for (host <- Try(c.getString("reporters.graphite.host"));
-           port <- Try(c.getInt("reporters.graphite.port")),
-             ) yield GraphiteConfig(
-               host, port, Try(c.getString("reporters.graphite.prefix")).toOption)).toOption
     val pollInterval = c.getDuration("poll-interval").toScala
     val lookupTableSize = c.getInt("lookup-table-size")
-    val prometheusPortLegacy = Try(c.getInt("port")).toOption
-    val prometheusPortNew = Try(c.getInt("reporters.prometheus.port")).toOption
-    val prometheusConfig = (prometheusPortNew orElse prometheusPortLegacy).map { port => PrometheusConfig(port) }
+
+    val metricWhitelist = c.getStringList("metric-whitelist").asScala.toList
+
+    val sinks = if (c.hasPath("sinks"))
+      c.getStringList("sinks").asScala.toList
+    else
+      List("PrometheusEndpointSink")
+
+    val sinkConfigs : List[SinkConfig] = sinks.flatMap { sink =>
+      sink match {
+        case "PrometheusEndpointSink" => Some(new PrometheusEndpointSinkConfig(sink, metricWhitelist, c))
+        case "InfluxDBPusherSink" => Some(new InfluxDBPusherSinkConfig(sink, metricWhitelist, c))
+        case "GraphicEndpointSink" => Some(new GraphiteEndpointConfig(sink, metricWhitelist, c))
+        case _ => None
+      }
+    }
+
     val clientGroupId = c.getString("client-group-id")
     val kafkaClientTimeout = c.getDuration("kafka-client-timeout").toScala
     val clusters = c.getConfigList("clusters").asScala.toList.map { clusterConfig =>
@@ -73,8 +82,8 @@ object AppConfig {
       )
     }
     val strimziWatcher = c.getString("watchers.strimzi").toBoolean
-    val metricWhitelist = c.getStringList("metric-whitelist").asScala.toList
-    AppConfig(pollInterval, lookupTableSize, clientGroupId, kafkaClientTimeout, clusters, strimziWatcher, metricWhitelist, prometheusConfig, graphiteConfig)
+
+    AppConfig(pollInterval, lookupTableSize, sinkConfigs, clientGroupId, kafkaClientTimeout, clusters, strimziWatcher)
   }
 
   // Copied from Alpakka Kafka
@@ -127,36 +136,22 @@ final case class KafkaCluster(name: String, bootstrapBrokers: String,
      """.stripMargin
   }
 }
-final case class AppConfig(pollInterval: FiniteDuration, lookupTableSize: Int, clientGroupId: String,
-                           clientTimeout: FiniteDuration, clusters: List[KafkaCluster], strimziWatcher: Boolean,
-                           metricWhitelist: List[String],
-                           prometheusConfig: Option[PrometheusConfig],
-                           graphiteConfig: Option[GraphiteConfig]) {
+
+final case class AppConfig(pollInterval: FiniteDuration, lookupTableSize: Int, sinkConfigs: List[SinkConfig], clientGroupId: String,
+                           clientTimeout: FiniteDuration, clusters: List[KafkaCluster], strimziWatcher: Boolean) {
   override def toString(): String = {
-    val graphiteString =
-      graphiteConfig.map { graphite => s"""
-        |Graphite: 
-        |  host: ${graphite.host}
-        |  port: ${graphite.port}
-        |  prefix: ${graphite.prefix}
-        """.stripMargin }.getOrElse("")
-    val prometheusString =
-      prometheusConfig.map { prometheus => s"""
-        |Prometheus: 
-        |  port: ${prometheus.port}
-        """.stripMargin }.getOrElse("")
     val clusterString =
       if (clusters.isEmpty)
         "  (none)"
       else clusters.map(_.toString).mkString("\n")
+    val sinksString = sinkConfigs.mkString("")
     s"""
        |Poll interval: $pollInterval
        |Lookup table size: $lookupTableSize
-       |Metrics whitelist: [${metricWhitelist.mkString(", ")}]
+       |Metrics whitelist: [${sinkConfigs.head.metricWhitelist.mkString(", ")}]
        |Admin client consumer group id: $clientGroupId
        |Kafka client timeout: $clientTimeout
-       |$prometheusString
-       |$graphiteString
+       |$sinksString
        |Statically defined Clusters:
        |$clusterString
        |Watchers:

--- a/src/main/scala/com/lightbend/kafkalagexporter/EndpointSink.scala
+++ b/src/main/scala/com/lightbend/kafkalagexporter/EndpointSink.scala
@@ -25,4 +25,3 @@ abstract class EndpointSink (clusterGlobalLabels: ClusterGlobalLabels) extends M
     globalLabelNames.map(l => globalLabelValuesForCluster.getOrElse(l, ""))
   }
 }
-

--- a/src/main/scala/com/lightbend/kafkalagexporter/GraphiteConfig.scala
+++ b/src/main/scala/com/lightbend/kafkalagexporter/GraphiteConfig.scala
@@ -1,7 +1,0 @@
-/*
- * Copyright (C) 2019-2020 Lightbend Inc. <https://www.lightbend.com>
- */
-
-package com.lightbend.kafkalagexporter
-
-case class GraphiteConfig(host: String, port: Int, prefix: Option[String])

--- a/src/main/scala/com/lightbend/kafkalagexporter/GraphiteEndpointConfig.scala
+++ b/src/main/scala/com/lightbend/kafkalagexporter/GraphiteEndpointConfig.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2019 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package com.lightbend.kafkalagexporter
+
+import com.typesafe.config.Config
+import scala.util.Try
+
+class GraphiteEndpointConfig(sinkType: String, metricWhitelist: List[String], config: Config) extends SinkConfig(sinkType, metricWhitelist, config)
+{
+  val port: Int = config.getInt("reporters.graphite.port")
+  val host: String = config.getString("reporters.graphite.host")
+  val prefix: Option[String] = Try(config.getString("reporters.graphite.prefix")).toOption
+
+  override def toString(): String = {
+    s"""
+      |Graphite:
+      |  host: ${host}
+      |  port: ${port}
+      |  prefix: ${prefix}
+    """
+  }
+
+}

--- a/src/main/scala/com/lightbend/kafkalagexporter/GraphiteEndpointSink.scala
+++ b/src/main/scala/com/lightbend/kafkalagexporter/GraphiteEndpointSink.scala
@@ -14,16 +14,16 @@ import scala.util.Try
 
 object GraphiteEndpointSink {
 
-  def apply(metricWhitelist: List[String], clusterGlobalLabels: ClusterGlobalLabels,
-            graphiteConfig: Option[GraphiteConfig]): MetricsSink = {
-    Try(new GraphiteEndpointSink(metricWhitelist, clusterGlobalLabels, graphiteConfig))
+  def apply(graphiteConfig: GraphiteEndpointConfig, clusterGlobalLabels: ClusterGlobalLabels
+            ): MetricsSink = {
+    Try(new GraphiteEndpointSink(graphiteConfig, clusterGlobalLabels))
       .fold(t => throw new Exception("Could not create Graphite Endpoint", t), sink => sink)
   }
 }
 
-class GraphiteEndpointSink private(metricWhitelist: List[String], clusterGlobalLabels: ClusterGlobalLabels,
-                                      graphiteConfig: Option[GraphiteConfig]) extends EndpointSink(clusterGlobalLabels) {
-  def graphitePush(graphiteConfig: GraphiteConfig, metricName: String, metricValue: Double): Unit = {
+class GraphiteEndpointSink private(graphiteConfig: GraphiteEndpointConfig, clusterGlobalLabels:
+   ClusterGlobalLabels) extends EndpointSink(clusterGlobalLabels) {
+  def graphitePush(graphiteConfig: GraphiteEndpointConfig, metricName: String, metricValue: Double): Unit = {
     Try(new Socket(graphiteConfig.host, graphiteConfig.port)) match {
       case Success(socket) =>
         Try(new PrintWriter(socket.getOutputStream)) match {
@@ -44,23 +44,19 @@ class GraphiteEndpointSink private(metricWhitelist: List[String], clusterGlobalL
     *
     * @example { label1=value1, label2=value2, name=myName } => "value1.value2.myName"
     *
-    */ 
+    */
   def metricNameToGraphiteMetricName(metricValue: MetricValue): String = {
     (getGlobalLabelValuesOrDefault(metricValue.clusterName) ++ metricValue.labels
       ).map( x => x.replaceAll("\\.", "_")).mkString(".") + "." + metricValue.definition.name;
   }
 
   override def report(m: MetricValue): Unit = {
-    if (metricWhitelist.exists(m.definition.name.matches)) {
-      graphiteConfig.foreach { conf =>
-        graphitePush(conf, metricNameToGraphiteMetricName(m), m.value);
+    if (graphiteConfig.metricWhitelist.exists(m.definition.name.matches)) {
+      graphitePush(graphiteConfig, metricNameToGraphiteMetricName(m), m.value);
       }
     }
-  }
 
   override def remove(m: RemoveMetric): Unit = {
   }
 
-
 }
-

--- a/src/main/scala/com/lightbend/kafkalagexporter/InfluxDBPusherSink.scala
+++ b/src/main/scala/com/lightbend/kafkalagexporter/InfluxDBPusherSink.scala
@@ -36,7 +36,7 @@ class InfluxDBPusherSink private(sinkConfig: InfluxDBPusherSinkConfig, clusterGl
 
   override def report(m: MetricValue): Unit = {
     if (sinkConfig.metricWhitelist.exists(m.definition.name.matches)) {
-      if (!m.value.isNaN) {
+      if (!m.value.isNaN && !m.value.isInfinite) {
         write(m)
       }
     }

--- a/src/main/scala/com/lightbend/kafkalagexporter/InfluxDBPusherSink.scala
+++ b/src/main/scala/com/lightbend/kafkalagexporter/InfluxDBPusherSink.scala
@@ -1,0 +1,143 @@
+/*
+ * Copyright (C) 2019 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package com.lightbend.kafkalagexporter
+
+import com.lightbend.kafkalagexporter.MetricsSink._
+import com.lightbend.kafkalagexporter.EndpointSink.ClusterGlobalLabels
+import org.influxdb.{InfluxDB, InfluxDBFactory, BatchOptions}
+import org.influxdb.InfluxDB.ConsistencyLevel
+import org.influxdb.dto.{Query, Point, BatchPoints}
+import java.io.IOException
+import java.util.function.Consumer
+import java.util.function.BiConsumer
+import org.influxdb.dto.QueryResult
+import java.lang.Iterable
+import com.typesafe.scalalogging.Logger
+
+import scala.util.Try
+
+object InfluxDBPusherSink
+{
+  def apply(sinkConfig: InfluxDBPusherSinkConfig, clusterGlobalLabels: ClusterGlobalLabels): MetricsSink =
+    {
+    Try(new InfluxDBPusherSink(sinkConfig, clusterGlobalLabels))
+      .fold(t => throw new IOException("Could not create Influx DB Pusher Sink", t), sink => sink)
+  }
+}
+
+class InfluxDBPusherSink private(sinkConfig: InfluxDBPusherSinkConfig, clusterGlobalLabels: ClusterGlobalLabels) extends EndpointSink(clusterGlobalLabels) {
+
+  val logger = Logger("InfluxDBPusherSink")
+  val influxDB = connect()
+  createDatabase()
+  enableBatching()
+
+  override def report(m: MetricValue): Unit = {
+    if (sinkConfig.metricWhitelist.exists(m.definition.name.matches)) {
+      if (!m.value.isNaN) {
+        write(m)
+      }
+    }
+  }
+
+  def write(m: MetricValue): Unit = {
+    try {
+      val point = buildPoint(m)
+      if (sinkConfig.async)
+        writeAsync(point)
+      else
+        writeSync(point)
+     } catch {
+      case t: Throwable =>
+        handlingFailure(t)
+    }
+  }
+
+  def writeAsync(point: Point): Unit = {
+    influxDB.write(point)
+  }
+
+  def writeSync(point: Point): Unit = {
+    val batchPoints = BatchPoints
+                .database(sinkConfig.database)
+                .consistency(ConsistencyLevel.ALL)
+                .build()
+
+    batchPoints.point(point)
+    influxDB.write(batchPoints)
+  }
+
+  def buildPoint(m: MetricValue): Point = {
+    val point = Point.measurement(m.definition.name)
+    val fields = m.definition.labels zip m.labels
+    fields.foreach { field => point.tag(field._1, field._2) }
+    point.addField("value", m.value)
+    return point.build()
+  }
+
+  override def remove(m: RemoveMetric): Unit = {
+    if (sinkConfig.metricWhitelist.exists(m.definition.name.matches))
+      logger.warn("Remove is not supported by InfluxDBPusherSink")
+  }
+
+  def enableBatching(): Unit = {
+    if (sinkConfig.async) {
+      influxDB.setDatabase(sinkConfig.database)
+      influxDB.enableBatch(BatchOptions.DEFAULTS.exceptionHandler(createExceptionHandler()))
+    }
+  }
+
+  def connect(): InfluxDB =
+  {
+    val url = sinkConfig.endpoint + ":" + sinkConfig.port
+    if (!sinkConfig.username.isEmpty) return InfluxDBFactory.connect(url, sinkConfig.username, sinkConfig.password)
+    else return InfluxDBFactory.connect(url)
+  }
+
+  def createDatabase() =
+  {
+    influxDB.query(new Query("CREATE DATABASE " + sinkConfig.database, sinkConfig.database), successQueryHandler(), failQueryHandler())
+  }
+
+  def successQueryHandler(): Consumer[QueryResult] =
+  {
+    return new Consumer[QueryResult] {
+      override def accept(result:QueryResult): Unit = {
+        logger.info(result.toString())
+      }
+    }
+  }
+
+  def failQueryHandler(): Consumer[Throwable] =
+  {
+    return new Consumer[Throwable] {
+      override def accept(throwable:Throwable): Unit = {
+        handlingFailure(throwable)
+      }
+    }
+  }
+
+  def createExceptionHandler(): BiConsumer[Iterable[Point], Throwable] =
+  {
+    return new BiConsumer[Iterable[Point], Throwable] {
+      override def accept(failedPoints:Iterable[Point], throwable:Throwable): Unit = {
+        handlingFailure(throwable)
+      }
+    }
+  }
+
+  def handlingFailure(t: Throwable): Unit = {
+    logger.error("Unrecoverable exception, will stop ", t)
+    stop()
+    throw t
+  }
+
+  override def stop(): Unit = {
+    if (influxDB.isBatchEnabled()) {
+      influxDB.disableBatch()
+    }
+    influxDB.close()
+  }
+}

--- a/src/main/scala/com/lightbend/kafkalagexporter/InfluxDBPusherSinkConfig.scala
+++ b/src/main/scala/com/lightbend/kafkalagexporter/InfluxDBPusherSinkConfig.scala
@@ -8,13 +8,13 @@ import com.typesafe.config.Config
 
 class InfluxDBPusherSinkConfig(sinkType: String, metricWhitelist: List[String], config: Config) extends SinkConfig(sinkType, metricWhitelist, config)
 {
-    val endpoint: String = config.getString("reporters.influxDB.endpoint")
-    val port: Int = config.getInt("reporters.influxDB.port")
+    val endpoint: String = config.getString("reporters.influxdb.endpoint")
+    val port: Int = config.getInt("reporters.influxdb.port")
     val defaultDatabase: String = "kafka_lag_exporter"
-    val database: String = if (config.hasPath("reporters.influxDB.database")) config.getString("reporters.influxDB.database") else defaultDatabase
-    val username: String = if (config.hasPath("reporters.influxDB.username")) config.getString("reporters.influxDB.username") else ""
-    val password: String = if (config.hasPath("reporters.influxDB.password")) config.getString("reporters.influxDB.password") else ""
-    val async: Boolean = if (config.hasPath("reporters.influxDB.async")) config.getBoolean("reporters.influxDB.async") else true
+    val database: String = if (config.hasPath("reporters.influxdb.database")) config.getString("reporters.influxdb.database") else defaultDatabase
+    val username: String = if (config.hasPath("reporters.influxdb.username")) config.getString("reporters.influxdb.username") else ""
+    val password: String = if (config.hasPath("reporters.influxdb.password")) config.getString("reporters.influxdb.password") else ""
+    val async: Boolean = if (config.hasPath("reporters.influxdb.async")) config.getBoolean("reporters.influxdb.async") else true
 
     override def toString(): String = {
       s"""

--- a/src/main/scala/com/lightbend/kafkalagexporter/InfluxDBPusherSinkConfig.scala
+++ b/src/main/scala/com/lightbend/kafkalagexporter/InfluxDBPusherSinkConfig.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2019 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package com.lightbend.kafkalagexporter
+
+import com.typesafe.config.Config
+
+class InfluxDBPusherSinkConfig(sinkType: String, metricWhitelist: List[String], config: Config) extends SinkConfig(sinkType, metricWhitelist, config)
+{
+    val endpoint: String = config.getString("reporters.influxDB.endpoint")
+    val port: Int = config.getInt("reporters.influxDB.port")
+    val defaultDatabase: String = "kafka_lag_exporter"
+    val database: String = if (config.hasPath("reporters.influxDB.database")) config.getString("reporters.influxDB.database") else defaultDatabase
+    val username: String = if (config.hasPath("reporters.influxDB.username")) config.getString("reporters.influxDB.username") else ""
+    val password: String = if (config.hasPath("reporters.influxDB.password")) config.getString("reporters.influxDB.password") else ""
+    val async: Boolean = if (config.hasPath("reporters.influxDB.async")) config.getBoolean("reporters.influxDB.async") else true
+
+    override def toString(): String = {
+      s"""
+        |InfluxDB:
+        |  endPoint: ${endpoint}
+        |  port: ${port}
+        |  database: ${database}
+        |  username: ${username}
+        |  async: ${async}
+      """
+    }
+}

--- a/src/main/scala/com/lightbend/kafkalagexporter/MetricsReporter.scala
+++ b/src/main/scala/com/lightbend/kafkalagexporter/MetricsReporter.scala
@@ -24,7 +24,7 @@ object MetricsReporter {
     case (context, Stop(sender)) =>
       Behaviors.stopped { () =>
         metricsSink.stop()
-        context.log.info("Gracefully stopped Prometheus metrics endpoint HTTP server")
+        context.log.info("Gracefully stopped metrics sink")
         sender ! KafkaClusterManager.Done
       }
     case (context, m) =>

--- a/src/main/scala/com/lightbend/kafkalagexporter/MetricsReporter.scala
+++ b/src/main/scala/com/lightbend/kafkalagexporter/MetricsReporter.scala
@@ -24,7 +24,7 @@ object MetricsReporter {
     case (context, Stop(sender)) =>
       Behaviors.stopped { () =>
         metricsSink.stop()
-        context.log.info("Gracefully stopped metrics sink")
+        context.log.info(s"Gracefully stopped $metricsSink")
         sender ! KafkaClusterManager.Done
       }
     case (context, m) =>

--- a/src/main/scala/com/lightbend/kafkalagexporter/PrometheusConfig.scala
+++ b/src/main/scala/com/lightbend/kafkalagexporter/PrometheusConfig.scala
@@ -1,8 +1,0 @@
-/*
- * Copyright (C) 2019-2020 Lightbend Inc. <https://www.lightbend.com>
- */
-
-package com.lightbend.kafkalagexporter
-
-case class PrometheusConfig(port: Int)
-

--- a/src/main/scala/com/lightbend/kafkalagexporter/PrometheusEndpointSink.scala
+++ b/src/main/scala/com/lightbend/kafkalagexporter/PrometheusEndpointSink.scala
@@ -16,36 +16,40 @@ import scala.util.Try
 object PrometheusEndpointSink {
   type Metrics = Map[GaugeDefinition, Gauge]
 
-  def apply(definitions: MetricDefinitions, metricWhitelist: List[String], clusterGlobalLabels: ClusterGlobalLabels,
-            server: HTTPServer, registry: CollectorRegistry): MetricsSink = {
-    Try(new PrometheusEndpointSink(definitions, metricWhitelist, clusterGlobalLabels, server, registry))
+  def apply(sinkConfig: PrometheusEndpointSinkConfig, definitions: MetricDefinitions, clusterGlobalLabels: ClusterGlobalLabels, registry: CollectorRegistry): MetricsSink = {
+    Try(new PrometheusEndpointSink(sinkConfig: PrometheusEndpointSinkConfig, definitions, clusterGlobalLabels, new HTTPServer(sinkConfig.port), registry))
+      .fold(t => throw new Exception("Could not create Prometheus Endpoint", t), sink => sink)
+  }
+
+  def apply(sinkConfig: PrometheusEndpointSinkConfig, definitions: MetricDefinitions, clusterGlobalLabels: ClusterGlobalLabels, server: HTTPServer, registry: CollectorRegistry): MetricsSink = {
+    Try(new PrometheusEndpointSink(sinkConfig: PrometheusEndpointSinkConfig, definitions, clusterGlobalLabels, server, registry))
       .fold(t => throw new Exception("Could not create Prometheus Endpoint", t), sink => sink)
   }
 }
 
-class PrometheusEndpointSink private(definitions: MetricDefinitions, metricWhitelist: List[String], clusterGlobalLabels: ClusterGlobalLabels,
+class PrometheusEndpointSink private(sinkConfig: PrometheusEndpointSinkConfig, definitions: MetricDefinitions, clusterGlobalLabels: ClusterGlobalLabels,
                                      server: HTTPServer, registry: CollectorRegistry) extends EndpointSink(clusterGlobalLabels) {
   DefaultExports.initialize()
 
   private val metrics: Metrics = {
-    definitions.filter(d => metricWhitelist.exists(d.name.matches)).map { d =>
+    definitions.filter(d => sinkConfig.metricWhitelist.exists(d.name.matches)).map { d =>
       d -> Gauge.build()
         .name(d.name)
         .help(d.help)
         .labelNames(globalLabelNames ++ d.labels: _*)
         .register(registry)
     }.toMap
-  }
+   }
 
   override def report(m: MetricValue): Unit = {
-    if (metricWhitelist.exists(m.definition.name.matches)) {
+    if (sinkConfig.metricWhitelist.exists(m.definition.name.matches)) {
       val metric = metrics.getOrElse(m.definition, throw new IllegalArgumentException(s"No metric with definition ${m.definition.name} registered"))
       metric.labels(getGlobalLabelValuesOrDefault(m.clusterName) ++ m.labels: _*).set(m.value)
     }
   }
 
   override def remove(m: RemoveMetric): Unit = {
-    if (metricWhitelist.exists(m.definition.name.matches)) {
+    if (sinkConfig.metricWhitelist.exists(m.definition.name.matches)) {
       for {
         gauge <- metrics.get(m.definition)
       } {
@@ -63,6 +67,5 @@ class PrometheusEndpointSink private(definitions: MetricDefinitions, metricWhite
     registry.clear()
     server.stop()
   }
-
 
 }

--- a/src/main/scala/com/lightbend/kafkalagexporter/PrometheusEndpointSinkConfig.scala
+++ b/src/main/scala/com/lightbend/kafkalagexporter/PrometheusEndpointSinkConfig.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2019 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package com.lightbend.kafkalagexporter
+
+import com.typesafe.config.Config
+import java.net.ServerSocket
+import scala.util.{Failure, Success, Try}
+
+class PrometheusEndpointSinkConfig(sinkType: String, metricWhitelist: List[String], config: Config) extends SinkConfig(sinkType, metricWhitelist, config)
+{
+  val port: Int = getPort(config)
+
+  def getPort(config: Config): Int = {
+    if (config.hasPath("port")) { // legacy
+      config.getInt("port")
+    }
+    else if (config.hasPath("reporters.prometheus.port")) {
+      config.getInt("reporters.prometheus.port")
+    }
+    else {
+      Try(new ServerSocket(0)) match {
+        case Success(socket) =>
+          val freePort = socket.getLocalPort
+          socket.close()
+          freePort
+        case Failure(exception) => throw exception
+        }
+    }
+  }
+
+  override def toString(): String = {
+    s"""
+      |Prometheus:
+      |  port: ${port}
+    """
+  }
+}

--- a/src/main/scala/com/lightbend/kafkalagexporter/SinkConfig.scala
+++ b/src/main/scala/com/lightbend/kafkalagexporter/SinkConfig.scala
@@ -1,0 +1,13 @@
+/*
+ * Copyright (C) 2019 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package com.lightbend.kafkalagexporter
+import com.typesafe.config.{Config}
+
+abstract class SinkConfig(val sinkType: String, val metricWhitelist: List[String], val config: Config)
+{
+  override def toString(): String = {
+    ""
+  }
+}

--- a/src/test/scala/com/lightbend/kafkalagexporter/GraphiteEndpointSinkTest.scala
+++ b/src/test/scala/com/lightbend/kafkalagexporter/GraphiteEndpointSinkTest.scala
@@ -5,6 +5,8 @@
 package com.lightbend.kafkalagexporter
 
 import org.scalatest._
+import com.typesafe.config.{Config, ConfigFactory}
+import scala.collection.JavaConversions.mapAsJavaMap
 
 class GraphiteEndpointSinkTest extends fixture.FreeSpec with Matchers {
 
@@ -34,8 +36,11 @@ class GraphiteEndpointSinkTest extends fixture.FreeSpec with Matchers {
   "GraphiteEndpointSinkImpl should" - {
 
     "report only metrics which match the regex" in { fixture =>
-      val sink = GraphiteEndpointSink(List("kafka_consumergroup_group_max_lag"), Map("cluster" -> Map.empty),
-        Some(GraphiteConfig("localhost", fixture.server.server.getLocalPort(), None)))
+      val properties = Map(
+        "reporters.graphite.host" -> "localhost",
+        "reporters.graphite.port" -> fixture.server.server.getLocalPort()
+      )
+      val sink = GraphiteEndpointSink(new GraphiteEndpointConfig("GraphiteEndpointSink", List("kafka_consumergroup_group_max_lag"), ConfigFactory.parseMap(mapAsJavaMap(properties))), Map("cluster" -> Map.empty))
       sink.report(Metrics.GroupValueMessage(Metrics.MaxGroupOffsetLagMetric, "cluster", "group", 100))
       sink.report(Metrics.GroupValueMessage(Metrics.MaxGroupTimeLagMetric, "cluster", "group", 1))
       fixture.server.join()
@@ -45,4 +50,3 @@ class GraphiteEndpointSinkTest extends fixture.FreeSpec with Matchers {
   }
 
 }
-

--- a/src/test/scala/com/lightbend/kafkalagexporter/InfluxDBPusherSinkTest.scala
+++ b/src/test/scala/com/lightbend/kafkalagexporter/InfluxDBPusherSinkTest.scala
@@ -11,6 +11,7 @@
  import com.github.fsanaulla.scalatest.embedinflux.EmbeddedInfluxDB
  import org.scalatest.concurrent.{Eventually, IntegrationPatience}
  import org.scalatest.{Matchers, TryValues}
+ import org.scalatest.time.{Seconds, Millis , Span}
  import sys.process._
 
 class InfluxDBPusherSinkTest extends fixture.FreeSpec with Matchers
@@ -32,17 +33,22 @@ class InfluxDBPusherSinkTest extends fixture.FreeSpec with Matchers
     test(Fixture(properties, port))
   }
 
+  def doQuery(url: String, query: String): String = {
+    val database = "kafka_lag_exporter"
+    val cmd = Seq("curl", "-G", s"$url/query", "--data-urlencode", s"db=$database", "--data-urlencode", s"q=$query")
+    val output = cmd.!!
+    return output
+  }
+
   "InfluxDBPusherSinkImpl should" - {
 
     "create database" in { fixture =>
       val sink = InfluxDBPusherSink(new InfluxDBPusherSinkConfig("InfluxDBPusherSink", List("kafka_consumergroup_group_max_lag"), ConfigFactory.parseMap(mapAsJavaMap(fixture.properties))), Map("cluster" -> Map.empty))
-      Thread.sleep(1000)
       val port = fixture.port
       val url = s"http://localhost:$port"
       val query = "SHOW DATABASES"
-      val cmd = Seq("curl", "-G", s"$url/query", "--data-urlencode", s"q=$query")
-      val output = cmd.!!
-      output should include("kafka_lag_exporter")
+
+      eventually (timeout(Span(5, Seconds)), interval(Span(500, Millis))) { doQuery(url, query) should include("kafka_lag_exporter") }
     }
 
     "report metrics which match the regex" in { fixture =>
@@ -50,19 +56,14 @@ class InfluxDBPusherSinkTest extends fixture.FreeSpec with Matchers
       sink.report(Metrics.GroupValueMessage(Metrics.MaxGroupOffsetLagMetric, "cluster_test", "group_test", 100))
       sink.report(Metrics.GroupValueMessage(Metrics.MaxGroupTimeLagMetric, "cluster_test", "group_test", 101))
 
-      Thread.sleep(5000)
-
       val port = fixture.port
       val url = s"http://localhost:$port"
-      val database = "kafka_lag_exporter"
+
       val whitelist_query = "SELECT * FROM kafka_consumergroup_group_max_lag"
       val blacklist_query = "SELECT * FROM kafka_consumergroup_group_max_lag_seconds"
-      var cmd = Seq("curl", "-G", s"$url/query", "--data-urlencode", s"db=$database", "--data-urlencode", s"q=$whitelist_query")
-      var output = cmd.!!
-      output should (include("cluster_test") and include("group_test") and include("100"))
-      cmd = Seq("curl", "-G", s"$url/query", "--data-urlencode", s"db=$database", "--data-urlencode", s"q=$blacklist_query")
-      output = cmd.!!
-      output should (not include("cluster_test") and not include("group_test") and not include("101"))
+
+      eventually (timeout(Span(5, Seconds)), interval(Span(500, Millis))) { doQuery(url, whitelist_query) should (include("cluster_test") and include("group_test") and include("100")) }
+      eventually (timeout(Span(5, Seconds)), interval(Span(500, Millis))) { doQuery(url, blacklist_query) should (not include("cluster_test") and not include("group_test") and not include("101")) }
     }
   }
 }

--- a/src/test/scala/com/lightbend/kafkalagexporter/InfluxDBPusherSinkTest.scala
+++ b/src/test/scala/com/lightbend/kafkalagexporter/InfluxDBPusherSinkTest.scala
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2019-2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+ package com.lightbend.kafkalagexporter
+
+ import org.scalatest._
+ import com.typesafe.config.ConfigFactory
+ import scala.collection.JavaConversions.mapAsJavaMap
+ import com.github.fsanaulla.core.testing.configurations.InfluxUDPConf
+ import com.github.fsanaulla.scalatest.embedinflux.EmbeddedInfluxDB
+ import org.scalatest.concurrent.{Eventually, IntegrationPatience}
+ import org.scalatest.{Matchers, TryValues}
+ import sys.process._
+
+class InfluxDBPusherSinkTest extends fixture.FreeSpec with Matchers
+    with EmbeddedInfluxDB
+    with InfluxUDPConf
+    with TryValues
+    with Eventually
+    with IntegrationPatience {
+
+  case class Fixture(properties: Map[String, Any], port: Int)
+  type FixtureParam = Fixture
+
+  override def withFixture(test: OneArgTest): Outcome = {
+    val port: Int = 8086
+    val properties: Map[String, Any] = Map(
+      "reporters.influxDB.endpoint" -> "http://localhost",
+      "reporters.influxDB.port" -> port
+    )
+    test(Fixture(properties, port))
+  }
+
+  "InfluxDBPusherSinkImpl should" - {
+
+    "create database" in { fixture =>
+      val sink = InfluxDBPusherSink(new InfluxDBPusherSinkConfig("InfluxDBPusherSink", List("kafka_consumergroup_group_max_lag"), ConfigFactory.parseMap(mapAsJavaMap(fixture.properties))), Map("cluster" -> Map.empty))
+      Thread.sleep(1000)
+      val port = fixture.port
+      val url = s"http://localhost:$port"
+      val query = "SHOW DATABASES"
+      val cmd = Seq("curl", "-G", s"$url/query", "--data-urlencode", s"q=$query")
+      val output = cmd.!!
+      output should include("kafka_lag_exporter")
+    }
+
+    "report metrics which match the regex" in { fixture =>
+      val sink = InfluxDBPusherSink(new InfluxDBPusherSinkConfig("InfluxDBPusherSink", List("kafka_consumergroup_group_max_lag"), ConfigFactory.parseMap(mapAsJavaMap(fixture.properties))), Map("cluster" -> Map.empty))
+      sink.report(Metrics.GroupValueMessage(Metrics.MaxGroupOffsetLagMetric, "cluster_test", "group_test", 100))
+      sink.report(Metrics.GroupValueMessage(Metrics.MaxGroupTimeLagMetric, "cluster_test", "group_test", 101))
+
+      Thread.sleep(5000)
+
+      val port = fixture.port
+      val url = s"http://localhost:$port"
+      val database = "kafka_lag_exporter"
+      val whitelist_query = "SELECT * FROM kafka_consumergroup_group_max_lag"
+      val blacklist_query = "SELECT * FROM kafka_consumergroup_group_max_lag_seconds"
+      var cmd = Seq("curl", "-G", s"$url/query", "--data-urlencode", s"db=$database", "--data-urlencode", s"q=$whitelist_query")
+      var output = cmd.!!
+      output should (include("cluster_test") and include("group_test") and include("100"))
+      cmd = Seq("curl", "-G", s"$url/query", "--data-urlencode", s"db=$database", "--data-urlencode", s"q=$blacklist_query")
+      output = cmd.!!
+      output should (not include("cluster_test") and not include("group_test") and not include("101"))
+    }
+  }
+}

--- a/src/test/scala/com/lightbend/kafkalagexporter/InfluxDBPusherSinkTest.scala
+++ b/src/test/scala/com/lightbend/kafkalagexporter/InfluxDBPusherSinkTest.scala
@@ -34,8 +34,8 @@ class InfluxDBPusherSinkTest extends fixture.FreeSpec with Matchers
   override def withFixture(test: OneArgTest): Outcome = {
     val port: Int = 8086
     val properties: Map[String, Any] = Map(
-      "reporters.influxDB.endpoint" -> "http://localhost",
-      "reporters.influxDB.port" -> port
+      "reporters.influxdb.endpoint" -> "http://localhost",
+      "reporters.influxdb.port" -> port
     )
     test(Fixture(properties, port))
   }


### PR DESCRIPTION
Follow up of https://github.com/lightbend/kafka-lag-exporter/pull/130 after rebasing with latest release

Note: This retains currently supported Prometheus as the default sink, if it's not configured.