### PR TITLE
Filter Out NaN Values from Aggregate Metrics

### DIFF
--- a/src/main/scala/com/lightbend/kafkalagexporter/ConsumerGroupCollector.scala
+++ b/src/main/scala/com/lightbend/kafkalagexporter/ConsumerGroupCollector.scala
@@ -271,11 +271,11 @@ object ConsumerGroupCollector {
         reporter ! Metrics.GroupValueMessage(Metrics.MaxGroupOffsetLagMetric, config.cluster.name, group, maxOffsetLag.offsetLag)
         reporter ! Metrics.GroupValueMessage(Metrics.MaxGroupTimeLagMetric, config.cluster.name, group, maxTimeLag.timeLag)
 
-        val sumOffsetLag = groupValues.map(_.offsetLag).sum
+        val sumOffsetLag = groupValues.map(_.offsetLag).filter(offsetLag => !offsetLag.isNaN).sum
         reporter ! Metrics.GroupValueMessage(Metrics.SumGroupOffsetLagMetric, config.cluster.name, group, sumOffsetLag)
 
         for((topic, topicValues) <- groupValues.groupBy(_.gtp.topic)) {
-          val topicOffsetLag = topicValues.map(_.offsetLag).sum
+          val topicOffsetLag = topicValues.map(_.offsetLag).filter(offsetLag => !offsetLag.isNaN).sum
 
           reporter ! Metrics.GroupTopicValueMessage(Metrics.SumGroupTopicOffsetLagMetric, config.cluster.name, group, topic, topicOffsetLag)
         }

--- a/src/test/scala/com/lightbend/kafkalagexporter/ConsumerGroupCollectorSpec.scala
+++ b/src/test/scala/com/lightbend/kafkalagexporter/ConsumerGroupCollectorSpec.scala
@@ -250,7 +250,7 @@ class ConsumerGroupCollectorSpec extends FreeSpec with Matchers with TestData wi
 
     "topic offset lag metric" in {
       metrics.collectFirst {
-        case GroupTopicValueMessage(`SumGroupTopicOffsetLagMetric`, config.cluster.name, `groupId`, `topic`, value) if value.isNaN => true
+        case GroupTopicValueMessage(`SumGroupTopicOffsetLagMetric`, config.cluster.name, `groupId`, `topic`, value) if !value.isNaN => true
       }.nonEmpty shouldBe true
     }
   }


### PR DESCRIPTION
Fix for issue #125 

By filtering NaN values before summing offsets lags, aggregate metrics for `SumGroupOffsetLagMetric` and `SumGroupTopicOffsetLagMetric`will report a more accurate value instead of NaN.