### PR TITLE
Support multiple instances and extra labels for service monitor

### DIFF
--- a/charts/kafka-lag-exporter/templates/060-ServiceMonitor.yaml
+++ b/charts/kafka-lag-exporter/templates/060-ServiceMonitor.yaml
@@ -30,4 +30,7 @@ spec:
     {{- if .Values.prometheus.serviceMonitor.scrapeTimeout }}
     scrapeTimeout: {{ .Values.prometheus.serviceMonitor.scrapeTimeout }}
     {{- end }}
+  {{- if .Values.prometheus.serviceMonitor.additionalConfig }}
+{{ toYaml .Values.prometheus.serviceMonitor.additionalConfig | indent 2}}
+  {{- end }}
 {{- end }}

--- a/charts/kafka-lag-exporter/templates/060-ServiceMonitor.yaml
+++ b/charts/kafka-lag-exporter/templates/060-ServiceMonitor.yaml
@@ -19,6 +19,7 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "kafka-lag-exporter.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
       helm.sh/chart: {{ include "kafka-lag-exporter.chart" . }}
   namespaceSelector:
     matchNames:

--- a/charts/kafka-lag-exporter/values.yaml
+++ b/charts/kafka-lag-exporter/values.yaml
@@ -138,4 +138,8 @@ prometheus:
     # service monitor label selectors: https://github.com/helm/charts/blob/f5a751f174263971fafd21eee4e35416d6612a3d/stable/prometheus-operator/templates/prometheus/prometheus.yaml#L74
     # additionalLabels:
     #   prometheus: k8s
+    # additionalConfig:
+    #   targetLabels:
+    #   - prometheus
+    #   - app.kubernetes.io/name
 


### PR DESCRIPTION
Fix for : https://github.com/lightbend/kafka-lag-exporter/issues/170

Add instance label in order to distinguish between one chart and another deployed into same namespace
