### PR TITLE
Add release steps to serve Helm Charts Repository on Github Pages

### DIFF
--- a/scripts/build_charts_index.sh
+++ b/scripts/build_charts_index.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -e
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+
+cd $DIR/..
+
+REMOTE_URL_BASE=$1
+REMOTE_INDEX_URL=$2
+CHARTS_DIR=".helm-release-packages"
+
+EXISTING_INDEX=$(mktemp /tmp/index.yaml.XXXXXX)
+
+REMOTE_CODE=$(curl -s -L -w "%{http_code}" $REMOTE_INDEX_URL -o $EXISTING_INDEX)
+if [ $REMOTE_CODE -eq 200 ]; then
+  echo Adding new packages to existing index
+  helm repo index --merge $EXISTING_INDEX --url $REMOTE_URL_BASE CHARTS_DIR
+else
+  echo Creating new index
+  helm repo index --url $REMOTE_URL_BASE $CHARTS_DIR
+fi
+
+rm "${EXISTING_INDEX}"

--- a/scripts/package_chart.sh
+++ b/scripts/package_chart.sh
@@ -6,8 +6,11 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 
 cd $DIR/..
 
+CHARTS_DIR=".helm-release-packages"
+
 # Bundle Kafka Lag Exporter Helm Chart into a tarball artifact.  The `helm package` command will output the artifact
-# in the CWD it is executed from.
+# in the CHARTS_DIR.
 echo Package helm chart
-rm -f ./kafka-lag-exporter-*.tgz
-helm package ./charts/kafka-lag-exporter
+mkdir -p $CHARTS_DIR
+rm -f $CHARTS_DIR/kafka-lag-exporter-*.tgz
+helm package ./charts/kafka-lag-exporter -d $CHARTS_DIR

--- a/scripts/publish_charts_index.sh
+++ b/scripts/publish_charts_index.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+
+set -e
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+
+cd $DIR/..
+
+CHARTS_DIR=".helm-release-packages"
+GITHUB_PAGES_BRANCH="gh-pages"
+
+function pages_branch_missing() {
+    local existed_in_remote=$(git ls-remote --heads origin $GITHUB_PAGES_BRANCH)
+
+    [ -z "${existed_in_remote}" ]
+}
+
+function create_pages_branch() {
+  echo "Creating pages branch ${GITHUB_PAGES_BRANCH}"
+  git checkout --quiet --orphan $GITHUB_PAGES_BRANCH
+  git rm --quiet -rf .
+  git commit --quiet --allow-empty -m "Pages initial commit"
+  git push --quiet origin HEAD:refs/heads/$GITHUB_PAGES_BRANCH
+  git checkout --detach --quiet
+  git branch --quiet -d $GITHUB_PAGES_BRANCH
+}
+
+function add_pages_worktree() {
+  local worktree_dir=${1}
+
+  if pages_branch_missing; then
+    git worktree add --quiet --detach ${worktree_dir}
+    pushd ${worktree_dir} > /dev/null
+    create_pages_branch
+    popd > /dev/null
+  else
+    git worktree add --quiet ${worktree_dir} "origin/${GITHUB_PAGES_BRANCH}"
+  fi
+}
+
+function remove_pages_worktree() {
+  local worktree_dir=${1}
+  git worktree remove --force ${worktree_dir}
+  rm -rf ${worktree_dir}
+}
+
+function push_index() {
+  if [[ ! -f "${CHARTS_DIR}/index.yaml" ]]; then
+    return -1
+  fi
+
+  local worktree=$(mktemp -d /tmp/worktree.XXXXXX)
+  add_pages_worktree ${worktree}
+
+  cp ${CHARTS_DIR}/index.yaml ${worktree}/
+  pushd ${worktree} > /dev/null
+  git add index.yaml
+  git commit --quiet --message "Update index.yaml"
+  git push --quiet origin HEAD:refs/heads/$GITHUB_PAGES_BRANCH
+  popd > /dev/null
+
+  remove_pages_worktree ${worktree}
+}
+
+push_index
+
+


### PR DESCRIPTION
Currently Helm Charts are attached to Github Release. It's enough to install chart as is.

In our case we had to extend it with our deployment specific resources. The most correct way was to make our own chart having `kafka-lag-exporter` as a dependency. But in order to specify a dependency chart must he stored in Helm Charts Repository.

In this PR I've added few steps to serve Helm Charts Repository on Github Pages as explained here https://helm.sh/docs/topics/chart_repository/.

Changes summary:

1. store chart to a separate folder instead of project root
2. Try to download existing charts index
3. Use `helm index` providing existing index to build a new repository index
4. Create github pages branch if it does not exist on github
5. Fetch  github pages branch into separate git worktree
6. Copy new repository index to the new worktree
7. Commit worktree
8. Remove worktree