### PR TITLE
Add support for Consumer Group blacklisting (#69)

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,16 +263,17 @@ General Configuration (`kafka-lag-exporter{}`)
 
 Kafka Cluster Connection Details (`kafka-lag-exporter.clusters[]`)
 
-| Key                       | Default     | Required | Description                                                                                                                                                                                        |
-|---------------------------|-------------|----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `name`                    | `""`        | Yes      | A unique cluster name to for this Kafka connection detail object                                                                                                                                   |
-| `bootstrap-brokers`       | `""`        | Yes      | Kafka bootstrap brokers.  Comma delimited list of broker hostnames                                                                                                                                 |
-| `group-whitelist`         | `[".*"]`    | No       | A list of Regex of consumer groups monitored. For example, if you only wish to expose only certain groups with `input` and `output` prefixes, use `["^input-.+", "^output-.+"]`.                   |
-| `topic-whitelist`         | `[".*"]`    | No       | A list of Regex of topics monitored. For example, if you only wish to expose only certain topics, use either `["^topic.+"]` or `["topic1", "topic2"]`.                                             |
-| `topic-blacklist`         | `[]`        | No       | A list of Regex of topics **not** monitored. For example, if you wish **not** expose certain topics , use either `["^unmonitored-topic.+"]` or `["unmonitored-topic1", "unmonitored-topic2"]`.     |
-| `consumer-properties`     | `{}`        | No       | A map of key value pairs used to configure the `KafkaConsumer`. See the [Consumer Config](https://kafka.apache.org/documentation/#consumerconfigs) section of the Kafka documentation for options. |
-| `admin-client-properties` | `{}`        | No       | A map of key value pairs used to configure the `AdminClient`. See the [Admin Config](https://kafka.apache.org/documentation/#adminclientconfigs) section of the Kafka documentation for options.   |
-| `labels`                  | `{}`        | No       | A map of key value pairs will be set as additional custom labels per cluster for all the metrics in prometheus.                                                                                    |
+| Key                       | Default     | Required | Description                                                                                                                                                                                               |
+|---------------------------|-------------|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `name`                    | `""`        | Yes      | A unique cluster name to for this Kafka connection detail object                                                                                                                                          |
+| `bootstrap-brokers`       | `""`        | Yes      | Kafka bootstrap brokers.  Comma delimited list of broker hostnames                                                                                                                                        |
+| `group-whitelist`         | `[".*"]`    | No       | A list of Regex of consumer groups monitored. For example, if you only wish to expose certain groups with `input` and `output` prefixes, use `["^input-.+", "^output-.+"]`.                               |
+| `group-blacklist`         | `[]`        | No       | A list of Regex of consumer groups **not** monitored. For example, if you wish to **not** expose certain groups, use either `["^unmonitored-group.+"]` or `["unmonitored-group1", "unmonitored-group2"]`. |
+| `topic-whitelist`         | `[".*"]`    | No       | A list of Regex of topics monitored. For example, if you only wish to expose certain topics, use either `["^topic.+"]` or `["topic1", "topic2"]`.                                                         |
+| `topic-blacklist`         | `[]`        | No       | A list of Regex of topics **not** monitored. For example, if you wish to **not** expose certain topics, use either `["^unmonitored-topic.+"]` or `["unmonitored-topic1", "unmonitored-topic2"]`.          |
+| `consumer-properties`     | `{}`        | No       | A map of key value pairs used to configure the `KafkaConsumer`. See the [Consumer Config](https://kafka.apache.org/documentation/#consumerconfigs) section of the Kafka documentation for options.        |
+| `admin-client-properties` | `{}`        | No       | A map of key value pairs used to configure the `AdminClient`. See the [Admin Config](https://kafka.apache.org/documentation/#adminclientconfigs) section of the Kafka documentation for options.          |
+| `labels`                  | `{}`        | No       | A map of key value pairs will be set as additional custom labels per cluster for all the metrics in prometheus.                                                                                           |
 
 Watchers (`kafka-lag-exporters.watchers{}`)
 

--- a/charts/kafka-lag-exporter/templates/030-ConfigMap.yaml
+++ b/charts/kafka-lag-exporter/templates/030-ConfigMap.yaml
@@ -28,6 +28,14 @@ data:
             {{- end }}
           ]
           {{- end }}
+          {{- if $cluster.groupBlacklist }}
+          group-blacklist = [
+            {{- $lastIndex := sub (len $cluster.groupBlacklist) 1}}
+            {{- range $i, $blacklist := $cluster.groupBlacklist }}
+            {{ quote $blacklist }}{{- if ne $i $lastIndex -}}, {{ end }}
+            {{- end }}
+          ]
+          {{- end }}
           {{- if $cluster.topicWhitelist }}
           topic-whitelist = [
             {{- $lastIndex := sub (len $cluster.topicWhitelist) 1}}

--- a/charts/kafka-lag-exporter/values.yaml
+++ b/charts/kafka-lag-exporter/values.yaml
@@ -10,6 +10,8 @@ clusters: {}
 #    - "^unmonitored-topics-.+"
 #    groupWhitelist:
 #    - "^analytics-app-.+"
+#    groupBlacklist:
+#    - "^unmonitored-groups-.+"
 #    # Properties defined by org.apache.kafka.clients.consumer.ConsumerConfig
 #    # can be defined in this configuration section.
 #    # https://kafka.apache.org/documentation/#consumerconfigs
@@ -142,4 +144,3 @@ prometheus:
     #   targetLabels:
     #   - prometheus
     #   - app.kubernetes.io/name
-

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -43,8 +43,8 @@ object Dependencies {
   val AkkaTypedTestKit      = "com.typesafe.akka"       %% "akka-actor-testkit-typed"  % Version.Akka        % Test
   val AkkaStreamsTestKit    = "com.typesafe.akka"       %% "akka-stream-testkit"       % Version.Akka        % Test
   val MockitoScala          = "org.mockito"             %% "mockito-scala"             % "1.0.8"             % Test
-  val AlpakkaKafkaTestKit   = "com.typesafe.akka"       %% "akka-stream-kafka-testkit" % "2.0.4"             % Test excludeAll(jacksonExclusionRule, log4jExclusionRule, slf4jExclusionRule)
-  val Testcontainers        = "org.testcontainers"      %  "kafka"                     % "1.14.3"            % Test
+  val AlpakkaKafkaTestKit   = "com.typesafe.akka"       %% "akka-stream-kafka-testkit" % "2.0.6"             % Test excludeAll(jacksonExclusionRule, log4jExclusionRule, slf4jExclusionRule)
+  val Testcontainers        = "org.testcontainers"      %  "kafka"                     % "1.15.1"            % Test
   val AkkaHttp              = "com.typesafe.akka"       %% "akka-http"                 % "10.1.11"
   val EmbedInflux           = "com.github.fsanaulla"    %% "scalatest-embedinflux"     % "0.2.3"             % Test
 }

--- a/src/main/scala/com/lightbend/kafkalagexporter/AppConfig.scala
+++ b/src/main/scala/com/lightbend/kafkalagexporter/AppConfig.scala
@@ -62,6 +62,10 @@ object AppConfig {
         clusterConfig.getStringList("group-whitelist").asScala.toList
       else KafkaCluster.GroupWhitelistDefault
 
+      val groupBlacklist = if (clusterConfig.hasPath("group-blacklist"))
+        clusterConfig.getStringList("group-blacklist").asScala.toList
+      else KafkaCluster.GroupBlacklistDefault
+
       val topicWhitelist = if (clusterConfig.hasPath("topic-whitelist"))
         clusterConfig.getStringList("topic-whitelist").asScala.toList
       else KafkaCluster.TopicWhitelistDefault
@@ -74,6 +78,7 @@ object AppConfig {
         clusterConfig.getString("name"),
         clusterConfig.getString("bootstrap-brokers"),
         groupWhitelist,
+        groupBlacklist,
         topicWhitelist,
         topicBlacklist,
         consumerProperties,
@@ -115,12 +120,14 @@ object AppConfig {
 
 object KafkaCluster {
   val GroupWhitelistDefault = List(".*")
+  val GroupBlacklistDefault = List.empty[String]
   val TopicWhitelistDefault = List(".*")
   val TopicBlacklistDefault = List.empty[String]
 }
 
 final case class KafkaCluster(name: String, bootstrapBrokers: String,
                               groupWhitelist: List[String] = KafkaCluster.GroupWhitelistDefault,
+                              groupBlacklist: List[String] = KafkaCluster.GroupBlacklistDefault,
                               topicWhitelist: List[String] = KafkaCluster.TopicWhitelistDefault,
                               topicBlacklist: List[String] = KafkaCluster.TopicBlacklistDefault,
                               consumerProperties: Map[String, String] = Map.empty,
@@ -131,6 +138,7 @@ final case class KafkaCluster(name: String, bootstrapBrokers: String,
        |  Cluster name: $name
        |  Cluster Kafka bootstrap brokers: $bootstrapBrokers
        |  Consumer group whitelist: [${groupWhitelist.mkString(", ")}]
+       |  Consumer group blacklist: [${groupBlacklist.mkString(", ")}]
        |  Topic whitelist: [${topicWhitelist.mkString(", ")}]
        |  Topic blacklist: [${topicBlacklist.mkString(", ")}]
      """.stripMargin

--- a/src/main/scala/com/lightbend/kafkalagexporter/KafkaClient.scala
+++ b/src/main/scala/com/lightbend/kafkalagexporter/KafkaClient.scala
@@ -177,7 +177,8 @@ class KafkaClient private[kafkalagexporter](cluster: KafkaCluster,
   }
 
   private[kafkalagexporter] def getGroupIds(groups: util.Collection[ConsumerGroupListing]): List[String] =
-    groups.asScala.map(_.groupId()).toList.filter(g => cluster.groupWhitelist.exists(r => g.matches(r)))
+    groups.asScala.map(_.groupId()).toList
+      .filter(g => cluster.groupWhitelist.exists(r => g.matches(r)) && !cluster.groupBlacklist.exists(r => g.matches(r)))
 
   private[kafkalagexporter] def groupTopicPartitions(groupId: String, desc: ConsumerGroupDescription): List[Domain.GroupTopicPartition] = {
     val groupTopicPartitions = for {

--- a/src/test/scala/com/lightbend/kafkalagexporter/KafkaClientSpec.scala
+++ b/src/test/scala/com/lightbend/kafkalagexporter/KafkaClientSpec.scala
@@ -225,6 +225,41 @@ class KafkaClientSpec extends FreeSpec with Matchers with TestData with MockitoS
         val groupIds = client.getGroupIds(groups)
         groupIds shouldBe List.empty
       }
+
+      "will only fetch non blacklisted groups" in {
+        val tmpCluster = cluster.copy(groupBlacklist = List(groupIdIotData))
+        val (_,_,client) = getClient(tmpCluster)
+        val groupIds = client.getGroupIds(groups)
+        groupIds should contain theSameElementsAs List(groupId1, groupId2)
+      }
+
+      "will exclude groups that match with blacklist regex" in {
+        val tmpCluster = cluster.copy(groupBlacklist = List("testGroupId[0-9]"))
+        val (_,_,client) = getClient(tmpCluster)
+        val groupIds = client.getGroupIds(groups)
+        groupIds should contain theSameElementsAs List(groupIdIotData)
+      }
+
+      "will not return any groups when blacklist matches all" in {
+        val tmpCluster = cluster.copy(groupBlacklist = List(".*"))
+        val (_,_,client) = getClient(tmpCluster)
+        val groupIds = client.getGroupIds(groups)
+        groupIds shouldBe List.empty
+      }
+
+      "will only fetch whitelisted and non blacklisted groups" in {
+        val tmpCluster = cluster.copy(groupWhitelist = List(groupId1, groupId2), groupBlacklist = List(groupId2, groupIdIotData))
+        val (_,_,client) = getClient(tmpCluster)
+        val groupIds = client.getGroupIds(groups)
+        groupIds should contain theSameElementsAs List(groupId1)
+      }
+
+      "will include groups that match with whitelist regex and exclude groups that match with blacklist regex" in {
+        val tmpCluster = cluster.copy(groupWhitelist = List("iot-.+"), groupBlacklist = List("testGroupId[0-9]"))
+        val (_,_,client) = getClient(tmpCluster)
+        val groupIds = client.getGroupIds(groups)
+        groupIds should contain theSameElementsAs List(groupIdIotData)
+      }
     }
   }
 


### PR DESCRIPTION
Adds the ability to blacklist Kafka consumer groups in addition to, and
supplementary to, the existing group whitelist. Resolves #69.