### PR TITLE
Updated the standalone example with the latest docker version

### DIFF
--- a/examples/standalone/application.conf
+++ b/examples/standalone/application.conf
@@ -8,6 +8,22 @@ kafka-lag-exporter {
         location = "ny"
         zone = "us-east"
       }
+    },
+    {
+      name = "a-cluster-with-sasl-properties"
+      bootstrap-brokers = "a-1.cluster-a.xyzcorp.com:9092,a-2.cluster-a.xyzcorp.com:9092,a-3.cluster-a.xyzcorp.com:9092"
+      admin-client-properties = {
+        ssl.endpoint.identification.algorithm = "https"
+        security.protocol="SASL_SSL"
+        sasl.mechanism="PLAIN"
+        sasl.jaas.config="org.apache.kafka.common.security.plain.PlainLoginModule required username=\"USERNAME\" password=\"PASSWORD\";"
+      }
+      consumer-properties = {
+        ssl.endpoint.identification.algorithm = "https"
+        security.protocol="SASL_SSL"
+        sasl.mechanism="PLAIN"
+        sasl.jaas.config="org.apache.kafka.common.security.plain.PlainLoginModule required username=\"USERNAME\" password=\"PASSWORD\";"
+      }
     }
   ]
 }

--- a/examples/standalone/run-docker.sh
+++ b/examples/standalone/run-docker.sh
@@ -6,7 +6,7 @@ DIR="$(cd "$(dirname "$0")" && pwd)"
 # Note that this will only work on Linux.
 docker run -p 8000:8000 \
     -v $DIR:/opt/docker/conf/ \
-    lightbend/kafka-lag-exporter:0.4.0 \
+    lightbend/kafka-lag-exporter:0.6.6 \
     /opt/docker/bin/kafka-lag-exporter \
     -Dconfig.file=/opt/docker/conf/application.conf \
     -Dlogback.configurationFile=/opt/docker/conf/logback.xml


### PR DESCRIPTION
I started to the test `Kafka Lag Exporter` against a Confluent Cluster and failed with some strange timeout and EOF exceptions. It turned out that the docker was not up to date in the `run-docker.sh`. I updated the docker image version and also added another cluster example with sasl support (not sure if it's generally interesting xd).