### PR TITLE
fix: missing metrics during broker shutdown.

### DIFF
--- a/src/main/scala/com/lightbend/kafkalagexporter/KafkaClient.scala
+++ b/src/main/scala/com/lightbend/kafkalagexporter/KafkaClient.scala
@@ -106,11 +106,11 @@ object KafkaClient {
                                                   (implicit ec: ExecutionContext) extends AdminKafkaClientContract {
     private implicit val _clientTimeout: Duration = clientTimeout.toJava
 
-    private val listGroupOptions = new ListConsumerGroupsOptions().timeoutMs(_clientTimeout.toMillis.toInt)
+    private val listGroupOptions = new ListConsumerGroupsOptions().timeoutMs(5000)
     private val describeGroupOptions = new DescribeConsumerGroupsOptions().timeoutMs(_clientTimeout.toMillis.toInt)
     private val listConsumerGroupsOptions = new ListConsumerGroupOffsetsOptions().timeoutMs(_clientTimeout.toMillis.toInt)
 
-    def listConsumerGroups(): Future[util.Collection[ConsumerGroupListing]] = kafkaFuture(client.listConsumerGroups(listGroupOptions).all())
+    def listConsumerGroups(): Future[util.Collection[ConsumerGroupListing]] = kafkaFuture(client.listConsumerGroups(listGroupOptions).valid())
     def describeConsumerGroups(groupIds: List[String]): Future[util.Map[String, ConsumerGroupDescription]] =
       kafkaFuture(client.describeConsumerGroups(groupIds.asJava, describeGroupOptions).all())
     def listConsumerGroupOffsets(group: String): Future[util.Map[KafkaTopicPartition, OffsetAndMetadata]] =


### PR DESCRIPTION
Instead of forcing a reply from all brokers to a 'ListGroups' call, give it a shorter timeout and use only valid values. The broker that is currently shutting down will fail to answer and timeout after 5s, but all other metrics from other brokers are returned and used. As on clean shutdown broker hands over consumer groups to others then it should mean that also no metrics are actually lost.