### PR TITLE
Add imagePullSecrets into the Helm chart

### DIFF
--- a/charts/kafka-lag-exporter/templates/040-Deployment.yaml
+++ b/charts/kafka-lag-exporter/templates/040-Deployment.yaml
@@ -39,6 +39,10 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if .Values.image.pullSecrets }}
+          imagePullSecrets:
+{{ toYaml .Values.image.pullSecrets | indent 10 }}
+          {{- end }}
           {{- if .Values.env }}
           env:
 {{ toYaml .Values.env | indent 10 }}

--- a/charts/kafka-lag-exporter/values.yaml
+++ b/charts/kafka-lag-exporter/values.yaml
@@ -79,6 +79,7 @@ image:
   # If digest is set it will be used instead of tag to specify the image
   # digest: sha256:0f6387aa011e6eb7952ea211ac139bf8613ad3ef6954a1a5d910676d293bd610
   pullPolicy: Always
+  pullSecrets: []
 securityContext: {}
   # allowPrivilegeEscalation: false
   # runAsUser: 1001


### PR DESCRIPTION
This PR adds imagePullSecrets option into the Helm chart.

Why?

To avoid the need for patching this Helm chart to provide imagePullSecret for environments that use private Docker registries.

Signed-off-by: Khalid Hasanov <xalid.h@gmail.com>