### PR TITLE
support adding annotations to created service account

### DIFF
--- a/charts/kafka-lag-exporter/templates/000-ServiceAccount.yaml
+++ b/charts/kafka-lag-exporter/templates/000-ServiceAccount.yaml
@@ -12,4 +12,8 @@ metadata:
     helm.sh/chart: {{ include "kafka-lag-exporter.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+  {{- if .Values.serviceAccount.annotations }}
+  annotations:
+    {{ toYaml .Values.serviceAccount.annotations }}
+  {{- end }}
 {{- end }}

--- a/charts/kafka-lag-exporter/values.yaml
+++ b/charts/kafka-lag-exporter/values.yaml
@@ -48,6 +48,9 @@ serviceAccount:
   ## The name of the service account will be generated based on the release name, use nameOverride to override
   ## with a static name.
   # nameOverride: my-serviceaccount
+  ## Annotations to add to the service account (e.g., add IAM role to the service)
+  # annotations:
+  #     iam.gke.io/gcp-service-account: gke-workload@my-gcp-project.iam.gserviceaccount.com
 
 ## You can use regex to control the metrics exposed by Prometheus endpoint.
 ## Any metric that matches one of the regex in the whitelist will be exposed.


### PR DESCRIPTION
As stated in the inline comment in `values.yaml`, this is useful for adding IAM roles.