### PR TITLE
Use kafka_consumergroup_poll_time_ms metric as healthcheck

### DIFF
--- a/charts/kafka-lag-exporter/templates/040-Deployment.yaml
+++ b/charts/kafka-lag-exporter/templates/040-Deployment.yaml
@@ -53,7 +53,7 @@ spec:
           {{- end }}
           livenessProbe:
             httpGet:
-              path: /
+              path: /metrics?name[]=kafka_consumergroup_poll_time_ms
               port: http
             initialDelaySeconds: {{ .Values.livenessProbeInitialDelay }}
             periodSeconds: {{ .Values.livenessProbePeriodSeconds }}
@@ -62,7 +62,7 @@ spec:
             successThreshold: {{ .Values.livenessProbeSuccessThreshold }}
           readinessProbe:
             httpGet:
-              path: /
+              path: /metrics?name[]=kafka_consumergroup_poll_time_ms
               port: http
             initialDelaySeconds: {{ .Values.readinessProbeInitialDelay }}
             periodSeconds: {{ .Values.readinessProbePeriodSeconds }}


### PR DESCRIPTION
Update deployment template to use kafka_consumergroup_poll_time_ms metric for liveness and readiness probes as described in "Health Check" section of README. Using / as a healthcheck creates additional load as discussed in #49