### PR TITLE
render podAnnotations with template func

### DIFF
--- a/charts/kafka-lag-exporter/templates/040-Deployment.yaml
+++ b/charts/kafka-lag-exporter/templates/040-Deployment.yaml
@@ -21,7 +21,7 @@ spec:
       {{- if .Values.podAnnotations }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/030-ConfigMap.yaml") . | sha256sum }}
-{{ toYaml .Values.podAnnotations | indent 8 }}
+{{ tpl (toYaml .Values.podAnnotations) . | indent 8 }}
       {{- end }}
     spec:
       {{- if or .Values.watchers.strimzi .Values.serviceAccount.create }}


### PR DESCRIPTION
The changes herein allow podAnnotations to be templated, and thus reference helm values defined within them.

e.g.

```
# values.yaml

podAnnotations:
    ad.datadoghq.com/{{ .Chart.Name }}.check_names: '["openmetrics"]'
```