### PR TITLE
exclude empty result metric for $consumer_group 'All'

### DIFF
--- a/grafana/Kafka_Lag_Exporter_Dashboard.json
+++ b/grafana/Kafka_Lag_Exporter_Dashboard.json
@@ -101,7 +101,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "topk(50, kafka_consumergroup_group_max_lag_seconds{namespace=\"$namespace\",cluster_name=\"$cluster_name\",group=~\"$consumer_group\"})",
+          "expr": "topk(50, kafka_consumergroup_group_max_lag_seconds{namespace=\"$namespace\",cluster_name=\"$cluster_name\",group=~\"$consumer_group\",group!=\"\"})",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -187,7 +187,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "topk(25, kafka_consumergroup_group_lag_seconds{namespace=\"$namespace\",cluster_name=\"$cluster_name\",group=~\"$consumer_group\"})",
+          "expr": "topk(25, kafka_consumergroup_group_lag_seconds{namespace=\"$namespace\",cluster_name=\"$cluster_name\",group=~\"$consumer_group\",group!=\"\"})",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -275,7 +275,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "topk(50, kafka_consumergroup_group_max_lag{namespace=\"$namespace\",cluster_name=\"$cluster_name\",group=~\"$consumer_group\"})",
+          "expr": "topk(50, kafka_consumergroup_group_max_lag{namespace=\"$namespace\",cluster_name=\"$cluster_name\",group=~\"$consumer_group\",group!=\"\"})",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -361,7 +361,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "topk(25, kafka_consumergroup_group_lag{namespace=\"$namespace\",cluster_name=\"$cluster_name\",group=~\"$consumer_group\"})",
+          "expr": "topk(25, kafka_consumergroup_group_lag{namespace=\"$namespace\",cluster_name=\"$cluster_name\",group=~\"$consumer_group\",group!=\"\"})",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -476,7 +476,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "kafka_consumergroup_group_max_lag_seconds{namespace=\"$namespace\",cluster_name=\"$cluster_name\",group=~\"$consumer_group\"}",
+          "expr": "kafka_consumergroup_group_max_lag_seconds{namespace=\"$namespace\",cluster_name=\"$cluster_name\",group=~\"$consumer_group\",group!=\"\"}",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -484,7 +484,7 @@
           "refId": "A"
         },
         {
-          "expr": "kafka_consumergroup_group_max_lag{namespace=\"$namespace\",cluster_name=\"$cluster_name\",group=~\"$consumer_group\"}",
+          "expr": "kafka_consumergroup_group_max_lag{namespace=\"$namespace\",cluster_name=\"$cluster_name\",group=~\"$consumer_group\",group!=\"\"}",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -601,7 +601,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "max(kafka_consumergroup_group_lag_seconds{namespace=\"$namespace\",cluster_name=\"$cluster_name\",group=~\"$consumer_group\"}) by (group)",
+          "expr": "max(kafka_consumergroup_group_lag_seconds{namespace=\"$namespace\",cluster_name=\"$cluster_name\",group=~\"$consumer_group\",group!=\"\"}) by (group)",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -609,7 +609,7 @@
           "refId": "A"
         },
         {
-          "expr": "sum(kafka_consumergroup_group_offset{namespace=\"$namespace\",cluster_name=\"$cluster_name\",group=~\"$consumer_group\"})",
+          "expr": "sum(kafka_consumergroup_group_offset{namespace=\"$namespace\",cluster_name=\"$cluster_name\",group=~\"$consumer_group\",group!=\"\"})",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -617,7 +617,7 @@
           "refId": "B"
         },
         {
-          "expr": "sum((kafka_consumergroup_group_offset{namespace=\"$namespace\",cluster_name=\"$cluster_name\",group=~\"$consumer_group\"} * 0)\n+ on(namespace,cluster_name,topic,partition) group_left() kafka_partition_latest_offset{namespace=\"$namespace\",cluster_name=\"$cluster_name\"})",
+          "expr": "sum((kafka_consumergroup_group_offset{namespace=\"$namespace\",cluster_name=\"$cluster_name\",group=~\"$consumer_group\",group!=\"\"} * 0)\n+ on(namespace,cluster_name,topic,partition) group_left() kafka_partition_latest_offset{namespace=\"$namespace\",cluster_name=\"$cluster_name\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Sum of latest offsets",


### PR DESCRIPTION
Grafana Dashboard: If no specific 'Consumer Group' is selected (All) then only include metrics where 'group' label is present.

Currently there's a metric included and listed without a group (also not clear where this is coming from and why it's sometimes indicating a lag?!?)
Not sure if anyone else / everyone also has got this issue?

<img width="897" alt="Screenshot 2021-05-31 at 16 14 33" src="https://user-images.githubusercontent.com/10864443/120206723-d520a200-c22b-11eb-83af-1beb28cd5c37.png">
