### PR TITLE
feat: add support for different reporters in Helm chart

### DIFF
--- a/charts/kafka-lag-exporter/templates/030-ConfigMap.yaml
+++ b/charts/kafka-lag-exporter/templates/030-ConfigMap.yaml
@@ -70,6 +70,36 @@ data:
         }
         {{- end }}
       ]
+
+      {{- $sinks := list -}}
+      {{- if .Values.reporters.prometheus.enabled }}
+        {{- $sinks = append $sinks "\"PrometheusEndpointSink\"" }}
+      reporters.prometheus.port = {{ .Values.reporters.prometheus.port }}
+      {{- end  }}
+
+      {{- if .Values.reporters.graphite.enabled }}
+        {{- $sinks = append $sinks "\"GraphiteEndpointSink\"" }}
+      reporters.graphite.host = {{ .Values.reporters.graphite.host | quote }}
+      reporters.graphite.port = {{ .Values.reporters.graphite.port }}
+        {{- if .Values.reporters.graphite.prefix }}
+      reporters.graphite.prefix = {{ .Values.reporters.graphite.prefix | quote }}
+        {{- end  }}
+      {{- end  }}
+
+      {{- if .Values.reporters.influxdb.enabled }}
+        {{- $sinks = append $sinks "\"InfluxDBPusherSink\"" }}
+      reporters.influxdb.endpoint = {{ .Values.reporters.influxdb.endpoint | quote }}
+      reporters.influxdb.port = {{ .Values.reporters.influxdb.port }}
+      reporters.influxdb.database = {{ .Values.reporters.influxdb.database | quote }}
+        {{- if .Values.reporters.influxdb.username }}
+      reporters.influxdb.username = {{ .Values.reporters.influxdb.username | quote }}
+        {{- end  }}
+        {{- if .Values.reporters.influxdb.password }}
+      reporters.influxdb.password = {{ .Values.reporters.influxdb.password | quote }}
+        {{- end  }}
+      reporters.influxdb.async = {{ .Values.reporters.influxdb.async }}
+      {{- end  }}
+      sinks = [{{ join ", " $sinks }}]
       watchers = {
         strimzi = "{{ .Values.watchers.strimzi }}"
       }

--- a/charts/kafka-lag-exporter/values.yaml
+++ b/charts/kafka-lag-exporter/values.yaml
@@ -36,6 +36,37 @@ lookupTableSize: 60
 clientGroupId: "kafkalagexporter"
 ## The timeout when communicating with Kafka clusters
 kafkaClientTimeoutSeconds: 10
+## Reporters will send metrics to time series databases
+reporters:
+  prometheus:
+    ## Flag to enable the Prometheus metrics reporter
+    enabled: true
+    ## The port to run the Prometheus endpoint on
+    port: 8000
+  graphite:
+    ## Flag to enable the graphite metrics reporter
+    enabled: false
+    ## The graphite host to send metrics to
+    host: "http://graphite"
+    ## The graphite port to send metrics to
+    port: 2003
+    ## The graphite metric prefix
+    prefix: ""
+  influxdb:
+    ## Flag to enable the influxdb metrics reporter
+    enabled: false
+    ## The influxdb host to send metrics to
+    endpoint: "http://influxdb"
+    ## The influxdb port to send metrics to
+    port: 8086
+    ## The influxdb database to send metrics to
+    database: "kafka_lag_exporter"
+    ## The influxdb username to connect
+    username: ""
+    ## The influxdb password to connect
+    password: ""
+    ## Flag to enable influxdb async non-blocking write mode to send metrics
+    async: true
 ## Watchers will automatically discover and forget Kafka clusters
 watchers:
   ## The Strimzi Cluster Watcher automatically watches for `kafka.strimzi.io` group, `Kafka` kind resources and will


### PR DESCRIPTION
Allow reporter properties to be configured via Helm values so
that metrics can be reported to Graphite or InfluxDB

Refs #245

Example:
```
helm template --set reporters.influxdb.enabled=true -x templates/030-ConfigMap.yaml charts/kafka-lag-exporter

...
data:
  application.conf: |
    kafka-lag-exporter {
      port = 8000
      poll-interval = 30 seconds
      lookup-table-size = 60
      client-group-id = "kafkalagexporter"
      kafka-client-timeout = 10 seconds
      clusters = [
      ]
      reporters.prometheus.port = 8000
      reporters.influxdb.endpoint = "http://influxdb"
      reporters.influxdb.port = 8086
      reporters.influxdb.database = "kafka_lag_exporter"
      reporters.influxdb.async = true
      sinks = ["PrometheusEndpointSink", "InfluxDBPusherSink"]
      watchers = {
        strimzi = "false"
      }
      metric-whitelist = [
        ".*"
      ]
    }

    akka {
      loggers = ["akka.event.slf4j.Slf4jLogger"]
      loglevel = "DEBUG"
      logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"
    }
...
```