### PR TITLE
feat: report metrics during rebalancing or when consumer group metrics are empty

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -36,6 +36,7 @@ lazy val kafkaLagExporter =
         PrometheusHttpServer,
         ScalaJava8Compat,
         AkkaHttp,
+        GuavaCache,
         Logback,
         ScalaTest,
         AkkaTypedTestKit,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -38,6 +38,7 @@ object Dependencies {
   val Fabric8Client          = "io.fabric8"              %  "kubernetes-client"            % Version.Fabric8
   val ScalaJava8Compat       = "org.scala-lang.modules"  %% "scala-java8-compat"           % "0.9.0"
   val AkkaHttp               = "com.typesafe.akka"       %% "akka-http"                    % "10.1.11"
+  val GuavaCache             = "com.google.guava"        %  "guava"                        % "30.1.1-jre"
 
   /* Test */
   val AkkaTypedTestKit       = "com.typesafe.akka"       %% "akka-actor-testkit-typed"  % Version.Akka           % Test

--- a/src/test/scala/com/lightbend/kafkalagexporter/TestData.scala
+++ b/src/test/scala/com/lightbend/kafkalagexporter/TestData.scala
@@ -9,6 +9,7 @@ import com.lightbend.kafkalagexporter.Domain._
 import org.apache.kafka.common.Node
 
 trait TestData {
+  val cache = new GCache[Domain.GroupTopicPartition, LookupTable.Point](2, 1);
   val cluster = KafkaCluster("default", "brokers:9092")
   val node = new Node(1001, "brokers", 9092)
   val groupId = "testGroupId"


### PR DESCRIPTION
### Related issue:

* https://github.com/lightbend/kafka-lag-exporter/issues/63

### Description: 

* I'm not a "true" scala developer, but I would like to have a hand to fix the issue that I posted above. I really appreciate any help you can provide. 