### PR TITLE
Common usecase for a servicemonitor is to add additional labels to it…

### DIFF
--- a/charts/kafka-lag-exporter/templates/050-Service.yaml
+++ b/charts/kafka-lag-exporter/templates/050-Service.yaml
@@ -8,6 +8,9 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     jobLabel: {{ include "kafka-lag-exporter.fullname" . }}
+    {{- if .Values.service.additionalLabels }}
+{{ toYaml .Values.service.additionalLabels | indent 4 -}}
+    {{- end }}
   annotations:
     prometheus.io/path: /metrics
     prometheus.io/port: "{{ .Values.service.port }}"

--- a/charts/kafka-lag-exporter/values.yaml
+++ b/charts/kafka-lag-exporter/values.yaml
@@ -93,6 +93,7 @@ initContainers: []
 service:
   type: ClusterIP
   port: 8000
+  additionalLabels: {}
 resources: {}
   # limits:
   #  cpu: 100m


### PR DESCRIPTION
Common usecase for a servicemonitor is to add additional labels to the metrics via targetlabels (.spec.prometheus.servicemonitor.additionalConfig.targetLabels).  These labels are pulled from the Service though so we need to be able to add labels to a service.

Would appreciate it @seglo if we can get a new helm chart with this in it.  Thanks!